### PR TITLE
Slider mousewheel event

### DIFF
--- a/EarTrumpet/EarTrumpet.csproj
+++ b/EarTrumpet/EarTrumpet.csproj
@@ -58,6 +58,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Extensions\DoubleExtensions.cs" />
     <Compile Include="Extensions\BlurWindowExtensions.cs" />
     <Compile Include="Extensions\IconExtensions.cs" />
     <Compile Include="Extensions\SliderExtensions.cs" />

--- a/EarTrumpet/Extensions/DoubleExtensions.cs
+++ b/EarTrumpet/Extensions/DoubleExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using EarTrumpet.Services;
+
+namespace EarTrumpet.Extensions
+{
+    static class DoubleExtensions
+    {
+        public static double Bound(this double val, double min, double max)
+        {
+            return Math.Max(min, Math.Min(max, val));
+        }
+    }
+}

--- a/EarTrumpet/Extensions/SliderExtensions.cs
+++ b/EarTrumpet/Extensions/SliderExtensions.cs
@@ -9,7 +9,12 @@ namespace EarTrumpet.Extensions
         {
             var percent = point.X / slider.ActualWidth;
             var newValue = (slider.Maximum - slider.Minimum) * percent;
-            slider.Value = (newValue > slider.Maximum ? slider.Maximum : (newValue < slider.Minimum ? slider.Minimum : newValue));
+            slider.Value = newValue.Bound(slider.Minimum,slider.Maximum);
+        }
+
+        public static void ChangePositionByAmount(this Slider slider, double amount)
+        {
+            slider.Value = (slider.Value + amount).Bound(slider.Minimum, slider.Maximum);
         }
     }
 }

--- a/EarTrumpet/MainWindow.xaml
+++ b/EarTrumpet/MainWindow.xaml
@@ -220,7 +220,7 @@
                                     TouchMove="Slider_TouchMove"
                                     PreviewMouseDown="Slider_MouseDown"
                                     PreviewMouseUp="Slider_MouseUp"
-                                    MouseWheel="MouseWheel_Manipulation"
+                                    MouseWheel="Slider_MouseWheel"
                                     MouseMove="Slider_MouseMove" />
                             <TextBlock Grid.Column="2"
                                        Text="{Binding Volume, Mode=OneWay}"

--- a/EarTrumpet/MainWindow.xaml
+++ b/EarTrumpet/MainWindow.xaml
@@ -220,6 +220,7 @@
                                     TouchMove="Slider_TouchMove"
                                     PreviewMouseDown="Slider_MouseDown"
                                     PreviewMouseUp="Slider_MouseUp"
+                                    MouseWheel="MouseWheel_Manipulation"
                                     MouseMove="Slider_MouseMove" />
                             <TextBlock Grid.Column="2"
                                        Text="{Binding Volume, Mode=OneWay}"

--- a/EarTrumpet/MainWindow.xaml.cs
+++ b/EarTrumpet/MainWindow.xaml.cs
@@ -127,6 +127,13 @@ namespace EarTrumpet
             }
         }
 
+        private void MouseWheel_Manipulation(object sender, MouseWheelEventArgs e) {
+            var slider = (Slider)sender;
+            var amount = Math.Sign(e.Delta)*2.0;
+            slider.ChangePositionByAmount(amount);
+            e.Handled = true;
+        }
+
         private void UpdateTheme()
         {
             // Call UpdateTheme before UpdateWindowPosition in case sizes change with the theme.

--- a/EarTrumpet/MainWindow.xaml.cs
+++ b/EarTrumpet/MainWindow.xaml.cs
@@ -127,9 +127,10 @@ namespace EarTrumpet
             }
         }
 
-        private void MouseWheel_Manipulation(object sender, MouseWheelEventArgs e) {
+        private void Slider_MouseWheel(object sender, MouseWheelEventArgs e)
+        {
             var slider = (Slider)sender;
-            var amount = Math.Sign(e.Delta)*2.0;
+            var amount = Math.Sign(e.Delta) * 2.0;
             slider.ChangePositionByAmount(amount);
             e.Handled = true;
         }


### PR DESCRIPTION
New version of the slider mousewheel event that should better "fit in" with the rest of the project. 

Also used the newly added [double].Bound(min,max) in the SetPositionByControlPoint function instead of the rather complicated bounding with the ternary operator.
