### PR TITLE
Added "Playback devices" to tray context menu

### DIFF
--- a/EarTrumpet/Properties/Resources.Designer.cs
+++ b/EarTrumpet/Properties/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace EarTrumpet.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PlaybackDevices.
+        /// </summary>
+        public static string PlayBackDevices {
+            get {
+                return ResourceManager.GetString("PlayBackDevices", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to System Sounds.
         /// </summary>
         public static string SystemSoundsDisplayName {

--- a/EarTrumpet/Properties/Resources.resx
+++ b/EarTrumpet/Properties/Resources.resx
@@ -129,6 +129,9 @@
   <data name="NoAppsPanelContent" xml:space="preserve">
     <value>It doesn't look like you have any apps open.</value>
   </data>
+  <data name="PlayBackDevices" xml:space="preserve">
+    <value>Playback devices</value>
+  </data>
   <data name="SystemSoundsDisplayName" xml:space="preserve">
     <value>System Sounds</value>
   </data>

--- a/EarTrumpet/TrayIcon.cs
+++ b/EarTrumpet/TrayIcon.cs
@@ -25,16 +25,24 @@ namespace EarTrumpet
             _trayIcon.ContextMenu.MenuItems.Add(EarTrumpet.Properties.Resources.ContextMenuShowDesktopAppsTitle);
             _trayIcon.ContextMenu.MenuItems[1].Checked = UserPreferencesService.ShowDesktopApps;
             _trayIcon.ContextMenu.MenuItems[1].Click += ShowDesktopApps_Click;
-                
+
+            _trayIcon.ContextMenu.MenuItems.Add(EarTrumpet.Properties.Resources.PlayBackDevices);
+            _trayIcon.ContextMenu.MenuItems[2].Click += Devices_Click;
+
             _trayIcon.ContextMenu.MenuItems.Add("-");
 
             _trayIcon.ContextMenu.MenuItems.Add(EarTrumpet.Properties.Resources.ContextMenuExitTitle);
-            _trayIcon.ContextMenu.MenuItems[3].Click += Exit_Click;
+            _trayIcon.ContextMenu.MenuItems[4].Click += Exit_Click;
 
             _trayIcon.MouseClick += TrayIcon_MouseClick;
             _trayIcon.Icon = new System.Drawing.Icon(Application.GetResourceStream(new Uri("pack://application:,,,/EarTrumpet;component/Tray.ico")).Stream);
             _trayIcon.Text = "Ear Trumpet - Volume Control for Windows";
             _trayIcon.Visible = true;
+        }
+
+        private void Devices_Click(object sender, EventArgs e)
+        {
+            Process.Start("control", "mmsys.cpl");
         }
 
         void TrayIcon_MouseClick(object sender, System.Windows.Forms.MouseEventArgs e)


### PR DESCRIPTION
The original Windows devices tray icon also has this option in the context menu and I think that many users (including myself) use this to quickly change their playback device. So to make EarTrumpet a true replacement for the original Windows one I added this.