### PR TITLE
Improve window show time

### DIFF
--- a/EarTrumpet/EarTrumpet.csproj
+++ b/EarTrumpet/EarTrumpet.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Services\ThemeService.cs" />
     <Compile Include="Services\UserPreferencesService.cs" />
     <Compile Include="Services\UserSystemPreferencesService.cs" />
+    <Compile Include="Services\ProcessTitleProviderFactoryService.cs" />
     <Compile Include="TrayIcon.cs" />
     <Compile Include="ViewModels\AppItemViewModel.cs" />
     <Compile Include="Extensions\CollectionExtensions.cs" />

--- a/EarTrumpet/Services/ProcessTitleProviderFactoryService.cs
+++ b/EarTrumpet/Services/ProcessTitleProviderFactoryService.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EarTrumpet.Services
+{
+    public sealed class ProcessTitleProviderFactoryService
+    {
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+        private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+        [DllImport("user32", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
+        private static extern IntPtr GetWindow(IntPtr hwnd, GetWindowType wFlag);
+
+        enum GetWindowType : int
+        {
+            GW_HWNDFIRST = 0,
+            GW_HWNDLAST = 1,
+            GW_HWNDNEXT = 2,
+            GW_HWNDPREV = 3,
+            GW_OWNER = 4,
+            GW_CHILD = 5,
+            GW_ENABLEDPOPUP = 6,
+
+        }
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool IsWindowVisible(IntPtr hWnd);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+        public static ProcessTitleProvider CreateProvider()
+        {
+            var res = new Dictionary<uint, string>();
+            EnumWindows((handle, lParam) =>
+            {
+                var hr = GetWindow(handle, GetWindowType.GW_OWNER);
+                if (hr == (System.IntPtr)0 && IsWindowVisible(handle))
+                {
+                    uint processId;
+                    GetWindowThreadProcessId(handle, out processId);
+                    if (!res.ContainsKey(processId))
+                    {
+                        const int MAX_TITLE_LEN = 512;
+                        var sb = new System.Text.StringBuilder(MAX_TITLE_LEN);
+                        if (GetWindowText(handle, sb, MAX_TITLE_LEN - 1) > 0)
+                        {
+                            res.Add(processId, sb.ToString());
+                        }
+                    }
+                }
+                return true;
+            }, System.IntPtr.Zero);
+
+            return new ProcessTitleProvider(res);
+        }
+    }
+
+    public sealed class ProcessTitleProvider
+    {
+        public ProcessTitleProvider(Dictionary<uint, string> processTitles)
+        {
+            this._processTitles = processTitles;
+        }
+
+        private readonly Dictionary<uint, string> _processTitles;
+
+        public bool TryGetTitleForProcess(uint processId, out string processTitle)
+        {
+            return _processTitles.TryGetValue(processId, out processTitle);
+        }
+    }
+}

--- a/EarTrumpet/ViewModels/AppItemViewModel.cs
+++ b/EarTrumpet/ViewModels/AppItemViewModel.cs
@@ -43,7 +43,8 @@ namespace EarTrumpet.ViewModels
         public SolidColorBrush Background { get; set; }
         public bool IsDesktop { get; set; }
 
-        public AppItemViewModel(IAudioMixerViewModelCallback callback, EarTrumpetAudioSessionModelGroup sessions)
+        public AppItemViewModel(IAudioMixerViewModelCallback callback, EarTrumpetAudioSessionModelGroup sessions,
+            ProcessTitleProvider titleProvider)
         {
             _sessions = sessions;
             // select a session at random as sndvol does.
@@ -73,10 +74,10 @@ namespace EarTrumpet.ViewModels
 
                 try
                 {
-                    var proc = Process.GetProcessById((int)session.ProcessId);
-                    if (!string.IsNullOrWhiteSpace(proc.MainWindowTitle))
+                    string gotTitle;
+                    if (titleProvider.TryGetTitleForProcess(session.ProcessId, out gotTitle))
                     {
-                        DisplayName = proc.MainWindowTitle;
+                        DisplayName = gotTitle;
                     }
                 }
                 catch { } // we fallback to exe name if DisplayName is not set in the try above.

--- a/EarTrumpet/ViewModels/AudioMixerViewModel.cs
+++ b/EarTrumpet/ViewModels/AudioMixerViewModel.cs
@@ -46,7 +46,8 @@ namespace EarTrumpet.ViewModels
         {
             bool hasApps = Apps.Count > 0;
 
-            var sessions = _audioService.GetAudioSessionGroups().Select(x => new AppItemViewModel(_proxy, x));
+            var titleProvider = ProcessTitleProviderFactoryService.CreateProvider();
+            var sessions = _audioService.GetAudioSessionGroups().Select(x => new AppItemViewModel(_proxy, x, titleProvider));
 
             List<AppItemViewModel> staleSessionsToRemove = new List<AppItemViewModel>();
 


### PR DESCRIPTION
Eliminated calls to Process.GetProcessById() when refreshing the model on window show (which
is very slow -- over 500ms on my system) and instead getting process names via direct Win32 interop.