### PR TITLE
fix mismatch when muting from W10 volume mixer

### DIFF
--- a/EarTrumpet/ViewModels/AppItemViewModel.cs
+++ b/EarTrumpet/ViewModels/AppItemViewModel.cs
@@ -177,7 +177,7 @@ namespace EarTrumpet.ViewModels
 
         public void UpdateFromOther(AppItemViewModel other)
         {
-            if (_volume == other.Volume) return;
+            if (_volume == other.Volume && _isMuted == other.IsMuted) return;
             _sessions = other._sessions;
             _volume = other.Volume;
             _isMuted = other.IsMuted;


### PR DESCRIPTION
I noticed that when you mute from the native Windows volume mixer that EarTrumpet's internal state becomes out of sync. This change fixes it and should avoid any other problems with mismatching state.