### PR TITLE
Add middle click tray icon to toggle mute

### DIFF
--- a/EarTrumpet/TrayIcon.cs
+++ b/EarTrumpet/TrayIcon.cs
@@ -65,6 +65,11 @@ namespace EarTrumpet
             {
                 Invoked.Invoke();
             }
+
+            if (e.Button == System.Windows.Forms.MouseButtons.Middle)
+            {
+                _trayViewModel.ToggleDefaultAudioDeviceMute();
+            }
         }
 
         void Feedback_Click(object sender, EventArgs e)

--- a/EarTrumpet/ViewModels/TrayIconViewModel.cs
+++ b/EarTrumpet/ViewModels/TrayIconViewModel.cs
@@ -200,6 +200,12 @@ namespace EarTrumpet.ViewModels
         public void ToggleDefaultAudioDeviceMute()
         {
             var defaultDevice = GetAudioDevices().FirstOrDefault(x => x.IsDefault);
+
+            if (defaultDevice.Equals(default(EarTrumpetAudioDeviceModel)))
+            {
+                return;
+            }
+
             if (defaultDevice.IsMuted)
             {
                 _deviceService.UnmuteAudioDevice(defaultDevice.Id);

--- a/EarTrumpet/ViewModels/TrayIconViewModel.cs
+++ b/EarTrumpet/ViewModels/TrayIconViewModel.cs
@@ -197,6 +197,19 @@ namespace EarTrumpet.ViewModels
             _deviceService.SetDefaultAudioDevice(id);
         }
 
+        public void ToggleDefaultAudioDeviceMute()
+        {
+            var defaultDevice = GetAudioDevices().FirstOrDefault(x => x.IsDefault);
+            if (defaultDevice.IsMuted)
+            {
+                _deviceService.UnmuteAudioDevice(defaultDevice.Id);
+            }
+            else
+            {
+                _deviceService.MuteAudioDevice(defaultDevice.Id);
+            }
+        }
+
         public List<EarTrumpetAudioDeviceModel> GetAudioDevices()
         {
             return _deviceService.GetAudioDevices().ToList();


### PR DESCRIPTION
Hello fellow volume control replacement app makers. A long time ago I wrote a similar but less advanced app, where the primary feature was middle clicking the tray icon to toggle mute. I missed this a lot when trying out EarTrumpet, so here I am with this feature so I can permanently switch. Thanks!