### PR TITLE
Edit French translation

### DIFF
--- a/EarTrumpet/Properties/Resources.fr-FR.resx
+++ b/EarTrumpet/Properties/Resources.fr-FR.resx
@@ -210,7 +210,7 @@
     <value>Ouvrir le menu déroulant d'EarTrumpet</value>
   </data>
   <data name="SettingsUseLegacyEarTrumpetIcon" xml:space="preserve">
-    <value>Utiliser l'icône original d'EarTrumpet</value>
+    <value>Utiliser l'icône originale d'EarTrumpet</value>
   </data>
 
 </root>


### PR DESCRIPTION
Icône est généralement féminin, bien que le masculin soit aussi correct. D'où originale au féminin.
Icône is more often feminine in French, hence originale should be feminine too. Both are correct however.
Newline at the end of the file is not intended, it is added automatically by Github web editor.