### PR TITLE
Fix NOTIFYICONDATA struct layout and fallout

### DIFF
--- a/EarTrumpet/Interop/NotifyIconData.cs
+++ b/EarTrumpet/Interop/NotifyIconData.cs
@@ -11,6 +11,7 @@ namespace EarTrumpet.Interop
         NIF_STATE = 0x00000008,
         NIF_INFO = 0x00000010,
         NIF_GUID = 0x00000020,
+        NIF_SHOWTIP = 0x00000080
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -22,14 +23,14 @@ namespace EarTrumpet.Interop
         public NotifyIconFlags uFlags;
         public int uCallbackMessage;
         public IntPtr hIcon;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
         public string szTip;
         public int dwState;
         public int dwStateMask;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
         public string szInfo;
         public int uTimeoutOrVersion;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
         public string szInfoTitle;
         public int dwInfoFlags;
         public Guid guidItem;

--- a/EarTrumpet/UI/Helpers/ShellNotifyIcon.cs
+++ b/EarTrumpet/UI/Helpers/ShellNotifyIcon.cs
@@ -45,7 +45,7 @@ namespace EarTrumpet.UI.Helpers
         private bool _isCreated;
         private bool _isVisible;
         private bool _isListeningForInput;
-        private bool _isContextMenuOpen = false;
+        private bool _isContextMenuOpen;
         private string _text;
         private RECT _iconLocation;
         private System.Drawing.Point _cursorPosition;
@@ -253,6 +253,7 @@ namespace EarTrumpet.UI.Helpers
         {
             if (!_isContextMenuOpen)
             {
+                _isContextMenuOpen = true;
                 Trace.WriteLine("ShellNotifyIcon ShowContextMenu");
                 var contextMenu = new ContextMenu
                 {
@@ -284,7 +285,6 @@ namespace EarTrumpet.UI.Helpers
                     _isContextMenuOpen = false;
                 };
                 contextMenu.IsOpen = true;
-                _isContextMenuOpen = true;
             }
         }
     }


### PR DESCRIPTION
Fixes the issues in #460:

1. `NOTIFYICONDATAW` struct now has the correct layout, so `uVersion` is seen correctly as `NOTIFYICON_VERSION_4` by the shell
2. `uFlags` now has `NIF_SHOWTIP` so that the standard tooltip is still displayed with `NOTIFYICON_VERSION_4`
3. Tracks context menu state so that the multiple messages from the shell (due to `NOTIFYICON_VERSION_4`) on right-click do not cause the context menu to open and immediately close.

This might also fix the GUID handling, but I see that was removed recently.