### PR TITLE
Improve flyout open/close animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.7.0
+- Fixed crash when retrieving region info for GDPR compliance on some machines
+
 ## 2.1.6.0
 - Added ability to turn on/off crash reporting
 - Added missing translations

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -189,8 +189,8 @@ namespace EarTrumpet
                 "JE", // Jersey
                 "GG", // Guernsey
             };
-            var region = new RegionInfo(CultureInfo.CurrentCulture.LCID).TwoLetterISORegionName.ToUpper();
-            return !europeanUnionRegions.Contains(region);
+            var region = new Windows.Globalization.GeographicRegion();
+            return !europeanUnionRegions.Contains(region.CodeTwoLetter);
         }
     }
 }

--- a/EarTrumpet/UI/Helpers/WindowAnimationLibrary.cs
+++ b/EarTrumpet/UI/Helpers/WindowAnimationLibrary.cs
@@ -3,6 +3,7 @@ using EarTrumpet.Extensions;
 using EarTrumpet.Interop.Helpers;
 using System;
 using System.Windows;
+using System.Windows.Media;
 using System.Windows.Media.Animation;
 
 namespace EarTrumpet.UI.Helpers
@@ -15,6 +16,8 @@ namespace EarTrumpet.UI.Helpers
         {
             var onCompleted = new EventHandler((s, e) =>
             {
+                (window.RenderTransform as TranslateTransform).X = 0;
+                (window.RenderTransform as TranslateTransform).Y = 0;
                 window.Topmost = true;
                 window.Focus();
                 completed();
@@ -52,15 +55,21 @@ namespace EarTrumpet.UI.Helpers
             switch (taskbar.Location)
             {
                 case WindowsTaskbar.Position.Left:
-                case WindowsTaskbar.Position.Top:
+                    (window.RenderTransform as TranslateTransform).X = -_animationOffset;
                     moveAnimation.To = 0;
-                    moveAnimation.From = -_animationOffset;
+                    break;
+                case WindowsTaskbar.Position.Top:
+                    (window.RenderTransform as TranslateTransform).Y = -_animationOffset;
+                    moveAnimation.To = 0;
                     break;
                 case WindowsTaskbar.Position.Right:
+                    (window.RenderTransform as TranslateTransform).X = _animationOffset;
+                    moveAnimation.To = 0;
+                    break;
                 case WindowsTaskbar.Position.Bottom:
                 default:
+                    (window.RenderTransform as TranslateTransform).Y = _animationOffset;
                     moveAnimation.To = 0;
-                    moveAnimation.From = _animationOffset;
                     break;
             }
 
@@ -77,7 +86,7 @@ namespace EarTrumpet.UI.Helpers
 
             if (SystemSettings.IsTransparencyEnabled)
             {
-                window.Opacity = 0.5;
+                window.Opacity = 0.2;
             }
 
             window.Cloak(false);


### PR DESCRIPTION
Fixes #391.

This does a few things in the name of making the flyout open/close animation smoother. It should be noted that this is the "minimally-invasive" interpretation of a fix for this issue.

It tackles the problem by doing the following: 
1) Instead of moving the `Window`, the animation now applies a `TranslateTransform` to it.
2) This exposes the issue of acrylic being applied to the `Window`, and not a child control, and ignoring `LayoutTransform`s.
3) So now the Flyout's `LayoutRoot` has a background color applied to it, and the acrylic effect is no longer responsible for applying a color (aka gradient).
4) In addition, the acrylic effect is disabled while the open/close animations are playing. This has a minor "snapping" visual effect, especially as the opening animation finishes.

A visual demonstration, both recorded at 60 FPS:

Old|New
:-------------------------:|:-------------------------:
![old-flyout-open](https://user-images.githubusercontent.com/5133649/76134247-8e8ec880-6025-11ea-8717-73af06eb1a4b.gif) |![new-flyout-open](https://user-images.githubusercontent.com/5133649/76134282-b716c280-6025-11ea-9933-64a67fea3a9a.gif)



