### PR TITLE
Add missing RESX references to project

### DIFF
--- a/EarTrumpet/EarTrumpet.csproj
+++ b/EarTrumpet/EarTrumpet.csproj
@@ -376,6 +376,8 @@
     <Resource Include="Assets\Welcome.gif" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Properties\Resources.af.resx" />
+    <EmbeddedResource Include="Properties\Resources.cs.resx" />
     <EmbeddedResource Include="Properties\Resources.ko-KR.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>


### PR DESCRIPTION
When testing the new localization I noticed that 0cf9988f17faf13626d65b499ca23acf08050b6e forgot to add references to the new resources so I fixed that.