### PR TITLE
Fix cmds running against directories with spaces

### DIFF
--- a/EarTrumpet/EarTrumpet.csproj
+++ b/EarTrumpet/EarTrumpet.csproj
@@ -417,6 +417,6 @@
       <ChannelVersion>$(GitVersion_MajorMinorPatch).$(GitVersion_CommitsSinceVersionSource)</ChannelVersion>
     </PropertyGroup>
     <Message Text="GitVersion_InformationalVersion: $(GitVersion_InformationalVersion)" />
-    <Exec Command="powershell -executionpolicy Bypass -noprofile &quot;$(ProjectDir)\prebuild.ps1&quot; $(ChannelVersion)" />
+    <Exec Command="powershell -executionpolicy Bypass -noprofile &quot;&amp; '$(ProjectDir)prebuild.ps1'&quot; $(ChannelVersion)" />
   </Target>
 </Project>

--- a/EarTrumpet/prebuild.ps1
+++ b/EarTrumpet/prebuild.ps1
@@ -2,6 +2,6 @@
 
 $PackageManifestPath = "$PSScriptRoot\..\EarTrumpet.Package\Package.appxmanifest"
 
-$xml = [xml](Get-Content $PackageManifestPath)
+$xml = [xml](Get-Content "$PackageManifestPath")
 $xml.Package.Identity.Version = "$version"
-$xml.Save($PackageManifestPath)
+$xml.Save("$PackageManifestPath")


### PR DESCRIPTION
This fixes the build commands when running in directories with spaces. Targeted against dev this time.