### PR TITLE
Show zero-bar icon variant when device volume level at zero (fixes #478)

### DIFF
--- a/EarTrumpet/UI/Helpers/TaskbarIconSource.cs
+++ b/EarTrumpet/UI/Helpers/TaskbarIconSource.cs
@@ -126,6 +126,8 @@ namespace EarTrumpet.UI.Helpers
                     return IconHelper.LoadIconForTaskbar(SndVolSSO.GetPath(SndVolSSO.IconId.Muted), dpi);
                 case IconKind.NoDevice:
                     return IconHelper.LoadIconForTaskbar(SndVolSSO.GetPath(SndVolSSO.IconId.NoDevice), dpi);
+                case IconKind.SpeakerZeroBars:
+                    return IconHelper.LoadIconForTaskbar(SndVolSSO.GetPath(SndVolSSO.IconId.SpeakerZeroBars), dpi);
                 case IconKind.SpeakerOneBar:
                     return IconHelper.LoadIconForTaskbar(SndVolSSO.GetPath(SndVolSSO.IconId.SpeakerOneBar), dpi);
                 case IconKind.SpeakerTwoBars:
@@ -165,6 +167,8 @@ namespace EarTrumpet.UI.Helpers
                 {
                     case DeviceViewModel.DeviceIconKind.Mute:
                         return IconKind.Muted;
+                    case DeviceViewModel.DeviceIconKind.Bar0:
+                        return IconKind.SpeakerZeroBars;
                     case DeviceViewModel.DeviceIconKind.Bar1:
                         return IconKind.SpeakerOneBar;
                     case DeviceViewModel.DeviceIconKind.Bar2:

--- a/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
@@ -13,6 +13,7 @@ namespace EarTrumpet.UI.ViewModels
         public enum DeviceIconKind
         {
             Mute,
+            Bar0,
             Bar1,
             Bar2,
             Bar3,
@@ -128,9 +129,13 @@ namespace EarTrumpet.UI.ViewModels
                 {
                     IconKind = DeviceIconKind.Bar2;
                 }
-                else
+                else if (_device.Volume > 0.00f)
                 {
                     IconKind = DeviceIconKind.Bar1;
+                }
+                else
+                {
+                    IconKind = DeviceIconKind.Bar0;
                 }
             }
         }

--- a/EarTrumpet/UI/Views/DeviceView.xaml
+++ b/EarTrumpet/UI/Views/DeviceView.xaml
@@ -95,6 +95,9 @@
                                                     <DataTrigger Binding="{Binding Device.IconKind}" Value="Microphone">
                                                         <Setter Property="Text" Value="&#xE720;" />
                                                     </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Device.IconKind}" Value="Bar0">
+                                                        <Setter Property="Text" Value="&#xE992;" />
+                                                    </DataTrigger>
                                                     <DataTrigger Binding="{Binding Device.IconKind}" Value="Bar1">
                                                         <Setter Property="Text" Value="&#xE993;" />
                                                     </DataTrigger>


### PR DESCRIPTION
Microsoft is slowly changing the way they represent unmuted devices with a volume level of zero. This change aligns EarTrumpet behavior with expected behavior.

Windows 10, as of 21313.rs_prerelease.210209-1440, yields inconsistent results:
| Notification Area Icon 	| Flyout 	|
|------------------------	|--------	|
| 0 bars                 	| 1 bar  	|

EarTrumpet 2.1.8.0 behavior:
| Notification Area Icon 	| Flyout 	|
|------------------------	|--------	|
| 1 bar                 	| 1 bar  	|

EarTrumpet vNext behavior (this PR):
| Notification Area Icon 	| Flyout 	|
|------------------------	|--------	|
| 0 bars                 	| 0 bar  	|