### PR TITLE
Feature: Save expanded state between relaunches (#310)

### DIFF
--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -76,7 +76,7 @@ namespace EarTrumpet
             Exit += (_, __) => _trayIcon.IsVisible = false;
             CollectionViewModel.TrayPropertyChanged += () => _trayIcon.SetTooltip(CollectionViewModel.GetTrayToolTip());
 
-            _flyoutViewModel = new FlyoutViewModel(CollectionViewModel, () => _trayIcon.SetFocus());
+            _flyoutViewModel = new FlyoutViewModel(CollectionViewModel, () => _trayIcon.SetFocus(), _settings);
             FlyoutWindow = new FlyoutWindow(_flyoutViewModel);
             // Initialize the FlyoutWindow last because its Show/Hide cycle will pump messages, causing UI frames
             // to be executed, breaking the assumption that startup is complete.

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -90,6 +90,12 @@ namespace EarTrumpet
             }
         }
 
+        public bool IsExpanded
+        {
+            get => _settings.Get("IsExpanded", false);
+            set => _settings.Set("IsExpanded", value);
+        }
+
         public bool HasShownFirstRun
         {
             get => _settings.HasKey("hasShownFirstRun");

--- a/EarTrumpet/UI/ViewModels/FlyoutViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/FlyoutViewModel.cs
@@ -30,10 +30,13 @@ namespace EarTrumpet.UI.ViewModels
         private readonly DispatcherTimer _deBounceTimer;
         private readonly Dispatcher _currentDispatcher = Dispatcher.CurrentDispatcher;
         private readonly Action _returnFocusToTray;
+        private readonly AppSettings _settings;
         private bool _closedDuringOpen;
 
-        public FlyoutViewModel(DeviceCollectionViewModel mainViewModel, Action returnFocusToTray)
+        public FlyoutViewModel(DeviceCollectionViewModel mainViewModel, Action returnFocusToTray, AppSettings settings)
         {
+            _settings = settings;
+            IsExpanded = _settings.IsExpanded;
             Dialog = new ModalDialogViewModel();
             Devices = new ObservableCollection<DeviceViewModel>();
             _returnFocusToTray = returnFocusToTray;
@@ -127,11 +130,6 @@ namespace EarTrumpet.UI.ViewModels
                     throw new NotImplementedException();
             }
 
-            if (!CanExpand)
-            {
-                IsExpanded = false;
-            }
-
             UpdateTextVisibility();
             RaiseDevicesChanged();
         }
@@ -183,6 +181,7 @@ namespace EarTrumpet.UI.ViewModels
         public void DoExpandCollapse()
         {
             IsExpanded = !IsExpanded;
+            _settings.IsExpanded = IsExpanded;
             if (IsExpanded)
             {
                 // Add any that aren't existing.


### PR DESCRIPTION
Retry of #419.

In #310 original poster was talking about option to open EarTrumpet in maximized/expanded by default. I think we can avoid creating separate option if we save expanded state between relaunches.