### PR TITLE
mention `winget` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ We currently support 20+ languages. Are we missing your language? [Contribute a 
 
 ## Install
 
-Install EarTrumpet from the [Microsoft Store](https://www.microsoft.com/store/apps/9nblggh516xp) or via Chocolatey (`choco install eartrumpet`).
+Install EarTrumpet from the [Microsoft Store](https://www.microsoft.com/store/apps/9nblggh516xp)
+
+Or via command line using either
+- [Microsoft's winget](https://github.com/microsoft/winget-cli) (`winget install File-New-Project.EarTrumpet`)
+- Chocolatey (`choco install eartrumpet`).
 
 ## Experimental dev builds
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We currently support 20+ languages. Are we missing your language? [Contribute a 
 Install EarTrumpet from the [Microsoft Store](https://www.microsoft.com/store/apps/9nblggh516xp)
 
 Or via command line using either
-- [Microsoft's winget](https://github.com/microsoft/winget-cli) (`winget install File-New-Project.EarTrumpet`)
+- [Windows Package Manager Client (winget)](https://github.com/microsoft/winget-cli) (`winget install File-New-Project.EarTrumpet`)
 - Chocolatey (`choco install eartrumpet`).
 
 ## Experimental dev builds


### PR DESCRIPTION
Now that `winget` is shipping with windows by default, it should be listed in the readme.