### PR TITLE
For #831: Absolute volume control

### DIFF
--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -98,6 +98,8 @@ namespace EarTrumpet
             _settings.FlyoutHotkeyTyped += () => _flyoutViewModel.OpenFlyout(InputType.Keyboard);
             _settings.MixerHotkeyTyped += () => _mixerWindow.OpenOrClose();
             _settings.SettingsHotkeyTyped += () => _settingsWindow.OpenOrBringToFront();
+            _settings.AbsoluteVolumeUpHotkeyTyped += AbsoluteVolumeIncrement;
+            _settings.AbsoluteVolumeDownHotkeyTyped += AbsoluteVolumeDecrement;
             _settings.RegisterHotkeys();
 
             _trayIcon.PrimaryInvoke += (_, type) => _flyoutViewModel.OpenFlyout(type);
@@ -247,5 +249,32 @@ namespace EarTrumpet
         }
 
         private Window CreateMixerExperience() => new FullWindow { DataContext = new FullWindowViewModel(CollectionViewModel) };
+
+        private void AbsoluteVolumeIncrement()
+        {
+            foreach (var device in CollectionViewModel.AllDevices.Where(d => !d.IsMuted || d.IsAbsMuted))
+            {
+                // in any case this device is not abs muted anymore
+                device.IsAbsMuted = false;
+                device.IncrementVolume(2);
+            }
+        }
+
+        private void AbsoluteVolumeDecrement()
+        {
+            foreach (var device in CollectionViewModel.AllDevices.Where(d => !d.IsMuted))
+            {
+                // if device is not muted but will be muted by 
+                bool wasMuted = device.IsMuted;
+                // device.IncrementVolume(-2);
+                device.Volume -= 2;
+                // if device is muted by this absolute down
+                // .IsMuted is not already updated
+                if (!wasMuted == (device.Volume <= 0))
+                {
+                    device.IsAbsMuted = true;
+                }
+            }
+        }
     }
 }

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -12,6 +12,8 @@ namespace EarTrumpet
         public event Action FlyoutHotkeyTyped;
         public event Action MixerHotkeyTyped;
         public event Action SettingsHotkeyTyped;
+        public event Action AbsoluteVolumeUpHotkeyTyped;
+        public event Action AbsoluteVolumeDownHotkeyTyped;
 
         private ISettingsBag _settings = StorageFactory.GetSettings();
 
@@ -20,6 +22,8 @@ namespace EarTrumpet
             HotkeyManager.Current.Register(FlyoutHotkey);
             HotkeyManager.Current.Register(MixerHotkey);
             HotkeyManager.Current.Register(SettingsHotkey);
+            HotkeyManager.Current.Register(AbsoluteVolumeUpHotkey);
+            HotkeyManager.Current.Register(AbsoluteVolumeDownHotkey);
 
             HotkeyManager.Current.KeyPressed += (hotkey) =>
             {
@@ -37,6 +41,16 @@ namespace EarTrumpet
                 {
                     Trace.WriteLine("AppSettings MixerHotkeyTyped");
                     MixerHotkeyTyped?.Invoke();
+                }
+                else if (hotkey.Equals(AbsoluteVolumeUpHotkey))
+                {
+                    Trace.WriteLine("AppSettings AbsoluteVolumeUpHotkeyTyped");
+                    AbsoluteVolumeUpHotkeyTyped?.Invoke();
+                }
+                else if (hotkey.Equals(AbsoluteVolumeDownHotkey))
+                {
+                    Trace.WriteLine("AppSettings AbsoluteVolumeDownHotkeyTyped");
+                    AbsoluteVolumeDownHotkeyTyped?.Invoke();
                 }
             };
         }
@@ -71,6 +85,28 @@ namespace EarTrumpet
                 HotkeyManager.Current.Unregister(SettingsHotkey);
                 _settings.Set("SettingsHotkey", value);
                 HotkeyManager.Current.Register(SettingsHotkey);
+            }
+        }
+
+        public HotkeyData AbsoluteVolumeUpHotkey
+        {
+            get => _settings.Get("AbsoluteVolumeUpHotkey", new HotkeyData { });
+            set
+            {
+                HotkeyManager.Current.Unregister(AbsoluteVolumeUpHotkey);
+                _settings.Set("AbsoluteVolumeUpHotkey", value);
+                HotkeyManager.Current.Register(AbsoluteVolumeUpHotkey);
+            }
+        }
+
+        public HotkeyData AbsoluteVolumeDownHotkey
+        {
+            get => _settings.Get("AbsoluteVolumeDownHotkey", new HotkeyData { });
+            set
+            {
+                HotkeyManager.Current.Unregister(AbsoluteVolumeDownHotkey);
+                _settings.Set("AbsoluteVolumeDownHotkey", value);
+                HotkeyManager.Current.Register(AbsoluteVolumeDownHotkey);
             }
         }
 

--- a/EarTrumpet/Properties/Resources.Designer.cs
+++ b/EarTrumpet/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace EarTrumpet.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -1314,7 +1314,25 @@ namespace EarTrumpet.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to General.
+        ///   Looks up a localized string similar to Absolute Volume Down.
+        /// </summary>
+        public static string SettingsAbsoluteVolumeDownText {
+            get {
+                return ResourceManager.GetString("SettingsAbsoluteVolumeDownText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Absolute Volume Up.
+        /// </summary>
+        public static string SettingsAbsoluteVolumeUpText {
+            get {
+                return ResourceManager.GetString("SettingsAbsoluteVolumeUpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar à General.
         /// </summary>
         public static string SettingsCategoryTitle {
             get {

--- a/EarTrumpet/Properties/Resources.resx
+++ b/EarTrumpet/Properties/Resources.resx
@@ -296,8 +296,6 @@ Open [https://eartrumpet.app/jmp/fixfonts] now?</value>
   <data name="PrivacyCheckboxText" xml:space="preserve">
     <value>Send crash data to the EarTrumpet team</value>
   </data>
-
-  <!-- Actions add-on -->
   <data name="ActionAdditionalText" xml:space="preserve">
     <value>and</value>
   </data>
@@ -639,5 +637,11 @@ Open [https://eartrumpet.app/jmp/fixfonts] now?</value>
   </data>
   <data name="ChooseAnAppHelpText" xml:space="preserve">
     <value>Apps shown above have played sound recently.</value>
+  </data>
+  <data name="SettingsAbsoluteVolumeDownText" xml:space="preserve">
+    <value>Decrease volume for all devices</value>
+  </data>
+  <data name="SettingsAbsoluteVolumeUpText" xml:space="preserve">
+    <value>Increase volume for all devices</value>
   </data>
 </root>

--- a/EarTrumpet/UI/ViewModels/AudioSessionViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/AudioSessionViewModel.cs
@@ -8,11 +8,14 @@ namespace EarTrumpet.UI.ViewModels
     public class AudioSessionViewModel : BindableBase
     {
         private readonly IStreamWithVolumeControl _stream;
+        private bool _isAbsMuted;
 
         public AudioSessionViewModel(IStreamWithVolumeControl stream)
         {
             _stream = stream;
             _stream.PropertyChanged += Stream_PropertyChanged;
+
+            _isAbsMuted = false;
 
             ToggleMute = new RelayCommand(() => IsMuted = !IsMuted);
         }
@@ -34,6 +37,13 @@ namespace EarTrumpet.UI.ViewModels
             get => _stream.IsMuted;
             set => _stream.IsMuted = value;
         }
+
+        public bool IsAbsMuted
+        {
+            get => _isAbsMuted;
+            set => _isAbsMuted = value;
+        }
+
         public int Volume
         {
             get => _stream.Volume.ToVolumeInt();

--- a/EarTrumpet/UI/ViewModels/EarTrumpetShortcutsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetShortcutsPageViewModel.cs
@@ -15,6 +15,12 @@ namespace EarTrumpet.UI.ViewModels
         public HotkeyViewModel OpenSettingsHotkey { get; }
         public string DefaultSettingsHotKey => s_hotkeyNoneText;
 
+        public HotkeyViewModel AbsoluteVolumeUpHotkey { get; }
+        public string DefaultAbsoluteVolumeUpHotkey => s_hotkeyNoneText;
+
+        public HotkeyViewModel AbsoluteVolumeDownHotkey { get; }
+        public string DefaultAbsoluteVolumeDownHotkey => s_hotkeyNoneText;
+
         public EarTrumpetShortcutsPageViewModel(AppSettings settings) : base(null)
         {
             Title = Properties.Resources.ShortcutsPageText;
@@ -23,6 +29,8 @@ namespace EarTrumpet.UI.ViewModels
             OpenFlyoutHotkey = new HotkeyViewModel(settings.FlyoutHotkey, (newHotkey) => settings.FlyoutHotkey = newHotkey);
             OpenMixerHotkey = new HotkeyViewModel(settings.MixerHotkey, (newHotkey) => settings.MixerHotkey = newHotkey);
             OpenSettingsHotkey = new HotkeyViewModel(settings.SettingsHotkey, (newHotkey) => settings.SettingsHotkey = newHotkey);
+            AbsoluteVolumeUpHotkey = new HotkeyViewModel(settings.AbsoluteVolumeUpHotkey, (newHotkey) => settings.AbsoluteVolumeUpHotkey = newHotkey);
+            AbsoluteVolumeDownHotkey = new HotkeyViewModel(settings.AbsoluteVolumeDownHotkey, (newHotkey) => settings.AbsoluteVolumeDownHotkey = newHotkey);
         }
     }
 }

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -107,6 +107,58 @@
                                     Content="{Binding OpenSettingsHotkey}"
                                     IsTabStop="False" />
                 </Grid>
+                <TextBlock Style="{StaticResource BodyText}" Text="{x:Static resx:Resources.SettingsAbsoluteVolumeUpText}" />
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.DefaultHotkeyDescriptionText}" />
+                    <TextBlock Grid.Column="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodyText}"
+                               Text="{Binding DefaultSettingsHotKey}" />
+                    <TextBlock Grid.Row="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.HotkeyDescriptionText}" />
+                    <ContentControl Grid.Row="1"
+                                    Grid.Column="1"
+                                    Content="{Binding AbsoluteVolumeUpHotkey}"
+                                    IsTabStop="False" />
+                </Grid>
+                <TextBlock Style="{StaticResource BodyText}" Text="{x:Static resx:Resources.SettingsAbsoluteVolumeDownText}" />
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.DefaultHotkeyDescriptionText}" />
+                    <TextBlock Grid.Column="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodyText}"
+                               Text="{Binding DefaultSettingsHotKey}" />
+                    <TextBlock Grid.Row="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.HotkeyDescriptionText}" />
+                    <ContentControl Grid.Row="1"
+                                    Grid.Column="1"
+                                    Content="{Binding AbsoluteVolumeDownHotkey}"
+                                    IsTabStop="False" />
+                </Grid>
             </StackPanel>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:EarTrumpetLegacySettingsPageViewModel}">


### PR DESCRIPTION
## Implement an absolute volume control

An user can register 2 keys to control volume globally across all devices. A user muting a device with "normal" control cannot unmute with absolute control to prevent unwanted unmute.

The function `AbsoluteVolumeIncrement` and `AbsoluteVolumeDecrement` are in `App.xaml.xs` because I did not know if a new dedicated file is wanted for a such small addition or not. Tell me if you want to change the architecture to a cleaner structure.

The `absMuted` property is not set in the stream level because I did not see the value to set this low in the architecture. It is only needed by AudioSession. Again, I can change the location if wanted.

Compilation and run:
- [x] Debug
- [x] Release
- [x] VSDebug

Fixes: #831