### PR TITLE
Allow Windows key in shortcuts (Discussion #703)

### DIFF
--- a/EarTrumpet/Interop/Helpers/HotkeyData.cs
+++ b/EarTrumpet/Interop/Helpers/HotkeyData.cs
@@ -28,7 +28,15 @@ namespace EarTrumpet.Interop.Helpers
 
         public override string ToString()
         {
-            return (string)(new KeysConverter()).ConvertTo(Modifiers | Key, typeof(string));
+            var converter = new KeysConverter();
+            var mods = converter.ConvertToString(Modifiers);
+            if (Key == Keys.None) {
+                return mods;
+            } else
+            {
+                var key = converter.ConvertToString(Key);
+                return mods + "+" + key;
+            }
         }
 
         public override bool Equals(object obj)
@@ -60,6 +68,10 @@ namespace EarTrumpet.Interop.Helpers
             {
                 ret |= Keys.Shift;
             }
+            if ((modifiers & ModifierKeys.Win) == ModifierKeys.Win)
+            {
+                ret |= Keys.LWin;
+            }
             return ret;
         }
 
@@ -82,6 +94,14 @@ namespace EarTrumpet.Interop.Helpers
             if ((modifiers & Keys.Shift) == Keys.Shift)
             {
                 ret |= ModifierKeys.Shift;
+            }
+            if ((modifiers & Keys.LWin) == Keys.LWin)
+            {
+                ret |= ModifierKeys.Win;
+            }
+            if ((modifiers & Keys.RWin) == Keys.RWin)
+            {
+                ret |= ModifierKeys.Win;
             }
             return ret;
         }

--- a/EarTrumpet/Interop/Helpers/HotkeyData.cs
+++ b/EarTrumpet/Interop/Helpers/HotkeyData.cs
@@ -29,12 +29,24 @@ namespace EarTrumpet.Interop.Helpers
         public override string ToString()
         {
             var converter = new KeysConverter();
-            var mods = converter.ConvertToString(Modifiers);
-            if (Key == Keys.None) {
-                return mods;
-            } else
+            
+            string none = converter.ConvertToString(Keys.None);
+            // not sure why KeysConverter is returning stuff like "Control+None"
+            string mods = converter.ConvertToString(Modifiers).Replace("+" + none, "");
+            string key = converter.ConvertToString(Key);
+            
+            if (Key == Keys.None && Modifiers == Keys.None)
             {
-                var key = converter.ConvertToString(Key);
+                return "";
+            }
+            else if (Key == Keys.None) {
+                return mods;
+            }
+            else if (Modifiers == Keys.None) {
+                return key;
+            }
+            else
+            {
                 return mods + "+" + key;
             }
         }

--- a/EarTrumpet/Interop/Helpers/HotkeyData.cs
+++ b/EarTrumpet/Interop/Helpers/HotkeyData.cs
@@ -29,25 +29,29 @@ namespace EarTrumpet.Interop.Helpers
         public override string ToString()
         {
             var converter = new KeysConverter();
-            
+
+            // Discussion about why this looks odd can be found at
+            // https://github.com/File-New-Project/EarTrumpet/pull/1133
+
             string none = converter.ConvertToString(Keys.None);
-            // not sure why KeysConverter is returning stuff like "Control+None"
-            string mods = converter.ConvertToString(Modifiers).Replace("+" + none, "");
+            string modifierKeys = converter.ConvertToString(Modifiers).Replace($"+{none}", String.Empty);
             string key = converter.ConvertToString(Key);
-            
+
             if (Key == Keys.None && Modifiers == Keys.None)
             {
                 return "";
             }
-            else if (Key == Keys.None) {
-                return mods;
+            else if (Key == Keys.None)
+            {
+                return modifierKeys;
             }
-            else if (Modifiers == Keys.None) {
+            else if (Modifiers == Keys.None)
+            {
                 return key;
             }
             else
             {
-                return mods + "+" + key;
+                return $"{modifierKeys}+{key}";
             }
         }
 

--- a/EarTrumpet/UI/ViewModels/HotkeyViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/HotkeyViewModel.cs
@@ -80,6 +80,11 @@ namespace EarTrumpet.UI.ViewModels
                     _hotkey.Modifiers |= System.Windows.Forms.Keys.Alt;
                 }
 
+                if (Keyboard.IsKeyDown(Key.LWin) || Keyboard.IsKeyDown(Key.RWin))
+                {
+                    _hotkey.Modifiers |= System.Windows.Forms.Keys.LWin;
+                }
+
                 if (key == Key.LeftShift || key == Key.RightShift ||
                     key == Key.LeftAlt || key == Key.RightAlt ||
                     key == Key.LeftCtrl || key == Key.RightCtrl ||


### PR DESCRIPTION
Took a crack at #703. Wasn't sure if I should open a separate issue since there's already a request in discussions so sending this PR 

The main wrinkle with using the Windows key as a modifier is that it's not actually one according to the Windows API. This means that it doesn't have a nice value to use as a bitmask like `Keys.Control`, `Keys.Alt`, and `Keys.Shift` do. In fact there's a warning in the [`System.Windows.Forms.Keys` docs](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.keys?view=netframework-4.6.2#remarks) about this:

> Do not use the values in this enumeration for combined bitwise operations. The values in the enumeration are not mutually exclusive.

Looking at the actual values on that page, the modifiers' bits won't overlap with anything else while `LWin` and `RWin` overlap with many other keys:

```
  Key          Dec   Hex
  --------------------------
  Control   131072   0x20000
  Alt       262144   0x40000
  Shift      65536   0x10000
  LWin          91   0x0005B
  RWin          92   0x0005C
  A             65   0x00041
  B             66   0x00042
  C             67   0x00043
  (etc.)
```

This means `HotkeyData.ToString` needs to be careful not to bitwise or a non-modifier key with `LWin` or `RWin` when calling `KeysConverter.ConvertToString`.

For some reason that I haven't managed to figure out, `KeysConverter.ConvertToString(Keys.Control)` would return `"Control+None"`  and make the strings in the settings page ugly. I removed the extra `"+None"` but I'm not sure why it was doing that in the first place.

Also, since there's no combined `Win` key, I decided to handle `RWin` as if it were `LWin`. They could be split out but I felt like that wasn't a good idea because it breaks consistency with `Ctrl`/`Alt`/`Shift`. Leaving the string in the settings page with `"LWin"` so that it gets localized by `KeysConverter` even though it also could represent the `RWin` key.