### PR TITLE
Scroll anywhere to change volume while EarTrumpet is open (discussion #658)

### DIFF
--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -108,11 +108,19 @@ namespace EarTrumpet
             _trayIcon.PrimaryInvoke += (_, type) => _flyoutViewModel.OpenFlyout(type);
             _trayIcon.SecondaryInvoke += (_, args) => _trayIcon.ShowContextMenu(GetTrayContextMenuItems(), args.Point);
             _trayIcon.TertiaryInvoke += (_, __) => CollectionViewModel.Default?.ToggleMute.Execute(null);
-            _trayIcon.Scrolled += (_, wheelDelta) => CollectionViewModel.Default?.IncrementVolume(Math.Sign(wheelDelta) * 2);
+            _trayIcon.Scrolled += trayIconScrolled;
             _trayIcon.SetTooltip(CollectionViewModel.GetTrayToolTip());
             _trayIcon.IsVisible = true;
 
             DisplayFirstRunExperience();
+        }
+
+        private void trayIconScrolled(object _, int wheelDelta)
+        {
+            if (!_settings.UseGlobalMouseWheelHook || _flyoutViewModel.State == FlyoutViewState.Hidden)
+            {
+                CollectionViewModel.Default?.IncrementVolume(Math.Sign(wheelDelta) * 2);
+            }
         }
 
         private void DisplayFirstRunExperience()
@@ -227,6 +235,7 @@ namespace EarTrumpet
                 new SettingsPageViewModel[]
                     {
                         new EarTrumpetShortcutsPageViewModel(_settings),
+                        new EarTrumpetMouseSettingsPageViewModel(_settings),
                         new EarTrumpetLegacySettingsPageViewModel(_settings),
                         new EarTrumpetAboutPageViewModel(() => _errorReporter.DisplayDiagnosticData(), _settings)
                     });

--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -117,7 +117,7 @@ namespace EarTrumpet
 
         private void trayIconScrolled(object _, int wheelDelta)
         {
-            if (!_settings.UseGlobalMouseWheelHook || _flyoutViewModel.State == FlyoutViewState.Hidden)
+            if (_settings.UseScrollWheelInTray && (!_settings.UseGlobalMouseWheelHook || _flyoutViewModel.State == FlyoutViewState.Hidden))
             {
                 CollectionViewModel.Default?.IncrementVolume(Math.Sign(wheelDelta) * 2);
             }

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -132,6 +132,12 @@ namespace EarTrumpet
             set => _settings.Set("IsExpanded", value);
         }
 
+        public bool UseScrollWheelInTray
+        {
+            get => _settings.Get("UseScrollWheelInTray", true);
+            set => _settings.Set("UseScrollWheelInTray", value);
+        }
+
         public bool UseGlobalMouseWheelHook
         {
             get => _settings.Get("UseGlobalMouseWheelHook", false);

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -132,6 +132,12 @@ namespace EarTrumpet
             set => _settings.Set("IsExpanded", value);
         }
 
+        public bool UseGlobalMouseWheelHook
+        {
+            get => _settings.Get("UseGlobalMouseWheelHook", false);
+            set => _settings.Set("UseGlobalMouseWheelHook", value);
+        }
+
         public bool HasShownFirstRun
         {
             get => _settings.HasKey("hasShownFirstRun");

--- a/EarTrumpet/EarTrumpet.csproj
+++ b/EarTrumpet/EarTrumpet.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Interop\Helpers\AudioPolicyConfigFactoryImplFor21H2.cs" />
     <Compile Include="Interop\Helpers\AudioPolicyConfigFactoryImplForDownlevel.cs" />
     <Compile Include="Interop\Helpers\InputHelper.cs" />
+    <Compile Include="Interop\Helpers\MouseHook.cs" />
     <Compile Include="Interop\Helpers\SettingsPageHelper.cs" />
     <Compile Include="Interop\Helpers\PackageHelper.cs" />
     <Compile Include="Interop\IShellItemImageFactory.cs" />
@@ -231,6 +232,7 @@
     <Compile Include="UI\Themes\ThemeBindingInfo.cs" />
     <Compile Include="UI\Helpers\TaskbarIconSource.cs" />
     <Compile Include="UI\ViewModels\BackstackViewModel.cs" />
+    <Compile Include="UI\ViewModels\EarTrumpetMouseSettingsPageViewModel.cs" />
     <Compile Include="UI\ViewModels\EarTrumpetShortcutsPageViewModel.cs" />
     <Compile Include="Extensibility\IEarTrumpetAddonAppContent.cs" />
     <Compile Include="Extensibility\IEarTrumpetAddonDeviceContent.cs" />

--- a/EarTrumpet/Interop/Helpers/MouseHook.cs
+++ b/EarTrumpet/Interop/Helpers/MouseHook.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Windows.Forms;
+using System.Runtime.InteropServices;
+
+namespace EarTrumpet.Interop.Helpers
+{
+    public class MouseHook
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct POINT
+        {
+            public int x;
+            public int y;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct MouseLLHookStruct
+        {
+            public POINT pt;
+            public int mouseData;
+            public int flags;
+            public int time;
+            public int dwExtraInfo;
+        }
+
+        public delegate int MouseWheelHandler(object sender, MouseEventArgs e);
+        public event MouseWheelHandler MouseWheelEvent;
+
+        private const int WM_MOUSEWHEEL = 0x020A;
+        private const int WH_MOUSE_LL = 14;
+        private User32.HookProc _hProc;
+        private int _hHook;
+        private bool _hookIsSet = false;
+
+        public void SetHook()
+        {
+            if (!_hookIsSet)
+            {
+                _hProc = new User32.HookProc(MouseHookProc);
+                _hHook = User32.SetWindowsHookEx(WH_MOUSE_LL, _hProc, IntPtr.Zero, 0);
+                _hookIsSet = true;
+            }
+        }
+
+        public void UnHook()
+        {
+            if (_hookIsSet)
+            {
+                User32.UnhookWindowsHookEx(_hHook);
+                _hookIsSet = false;
+            }
+        }
+
+        private int MouseHookProc(int nCode, IntPtr wParam, IntPtr lParam)
+        {
+            if (nCode < 0 || MouseWheelEvent == null || (Int32)wParam != WM_MOUSEWHEEL)
+            {
+                return User32.CallNextHookEx(_hHook, nCode, wParam, lParam);
+            }
+            MouseLLHookStruct MyMouseHookStruct = (MouseLLHookStruct)Marshal.PtrToStructure(lParam, typeof(MouseLLHookStruct));
+            int result = MouseWheelEvent(this, new MouseEventArgs(MouseButtons.None, 0, MyMouseHookStruct.pt.x, MyMouseHookStruct.pt.y, MyMouseHookStruct.mouseData >> 16));
+            if (result == 0)
+            {
+                return User32.CallNextHookEx(_hHook, nCode, wParam, lParam);
+            }
+            return result;
+        }
+    }
+}

--- a/EarTrumpet/Interop/User32.cs
+++ b/EarTrumpet/Interop/User32.cs
@@ -347,5 +347,24 @@ namespace EarTrumpet.Interop
         public static extern uint GetGuiResources(
                 IntPtr hProcess,
                 GR_FLAGS uiFlags);
+
+        public delegate int HookProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll", PreserveSig = true)]
+        public static extern int SetWindowsHookEx(
+            int idHook,
+            HookProc lpfn,
+            IntPtr hInstance,
+            int threadId);
+
+        [DllImport("user32.dll", PreserveSig = true)]
+        public static extern bool UnhookWindowsHookEx(int idHook);
+
+        [DllImport("user32.dll", PreserveSig = true)]
+        public static extern int CallNextHookEx(
+            int idHook,
+            int nCode,
+            IntPtr wParam,
+            IntPtr lParam);
     }
 }

--- a/EarTrumpet/Properties/Resources.Designer.cs
+++ b/EarTrumpet/Properties/Resources.Designer.cs
@@ -684,6 +684,15 @@ namespace EarTrumpet.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Mouse settings.
+        /// </summary>
+        public static string MouseSettingsPageText {
+            get {
+                return ResourceManager.GetString("MouseSettingsPageText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Find a setting.
         /// </summary>
         public static string FindASettingText {
@@ -1400,6 +1409,15 @@ namespace EarTrumpet.Properties {
         public static string SettingsTitle {
             get {
                 return ResourceManager.GetString("SettingsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use the scroll wheel to change volume while the flyout is open.
+        /// </summary>
+        public static string SettingsUseGlobalMouseWheelHook {
+            get {
+                return ResourceManager.GetString("SettingsUseGlobalMouseWheelHook", resourceCulture);
             }
         }
         

--- a/EarTrumpet/Properties/Resources.Designer.cs
+++ b/EarTrumpet/Properties/Resources.Designer.cs
@@ -1431,6 +1431,15 @@ namespace EarTrumpet.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use the scroll wheel to change volume while hovering over the EarTrumpet icon.
+        /// </summary>
+        public static string SettingsUseScrollWheelInTray {
+            get {
+                return ResourceManager.GetString("SettingsUseScrollWheelInTray", resourceCulture);
+            }
+        }        
+        
+        /// <summary>
         ///   Looks up a localized string similar to Settings.
         /// </summary>
         public static string SettingsWindowText {

--- a/EarTrumpet/Properties/Resources.resx
+++ b/EarTrumpet/Properties/Resources.resx
@@ -650,4 +650,10 @@ Open [https://eartrumpet.app/jmp/fixfonts] now?</value>
   <data name="OpenAppsVolume_Windows11_Text" xml:space="preserve">
     <value>Volume mixer</value>
   </data>
+  <data name="MouseSettingsPageText" xml:space="preserve">
+    <value>Mouse settings</value>
+  </data>
+  <data name="SettingsUseGlobalMouseWheelHook" xml:space="preserve">
+    <value>Use the scroll wheel to change volume while the flyout is open</value>
+  </data>
 </root>

--- a/EarTrumpet/Properties/Resources.resx
+++ b/EarTrumpet/Properties/Resources.resx
@@ -653,6 +653,9 @@ Open [https://eartrumpet.app/jmp/fixfonts] now?</value>
   <data name="MouseSettingsPageText" xml:space="preserve">
     <value>Mouse settings</value>
   </data>
+  <data name="SettingsUseScrollWheelInTray" xml:space="preserve">
+    <value>Use the scroll wheel to change volume while hovering over the EarTrumpet icon</value>
+  </data>
   <data name="SettingsUseGlobalMouseWheelHook" xml:space="preserve">
     <value>Use the scroll wheel to change volume while the flyout is open</value>
   </data>

--- a/EarTrumpet/UI/ViewModels/EarTrumpetMouseSettingsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetMouseSettingsPageViewModel.cs
@@ -4,6 +4,12 @@ namespace EarTrumpet.UI.ViewModels
 {
     public class EarTrumpetMouseSettingsPageViewModel : SettingsPageViewModel
     {
+        public bool UseScrollWheelInTray
+        {
+            get => _settings.UseScrollWheelInTray;
+            set => _settings.UseScrollWheelInTray = value;
+        }
+
         public bool UseGlobalMouseWheelHook
         {
             get => _settings.UseGlobalMouseWheelHook;

--- a/EarTrumpet/UI/ViewModels/EarTrumpetMouseSettingsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetMouseSettingsPageViewModel.cs
@@ -1,0 +1,22 @@
+﻿
+
+namespace EarTrumpet.UI.ViewModels
+{
+    public class EarTrumpetMouseSettingsPageViewModel : SettingsPageViewModel
+    {
+        public bool UseGlobalMouseWheelHook
+        {
+            get => _settings.UseGlobalMouseWheelHook;
+            set => _settings.UseGlobalMouseWheelHook = value;
+        }
+
+        private readonly AppSettings _settings;
+
+        public EarTrumpetMouseSettingsPageViewModel(AppSettings settings) : base(null)
+        {
+            _settings = settings;
+            Title = Properties.Resources.MouseSettingsPageText;
+            Glyph = "\xE962";
+        }
+    }
+}

--- a/EarTrumpet/UI/ViewModels/FlyoutViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/FlyoutViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using EarTrumpet.UI.Helpers;
+using EarTrumpet.Interop.Helpers;
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -32,6 +33,8 @@ namespace EarTrumpet.UI.ViewModels
         private readonly Action _returnFocusToTray;
         private readonly AppSettings _settings;
         private bool _closedDuringOpen;
+        private MouseHook _mh;
+        private Rect _winRect;
 
         public FlyoutViewModel(DeviceCollectionViewModel mainViewModel, Action returnFocusToTray, AppSettings settings)
         {
@@ -56,6 +59,14 @@ namespace EarTrumpet.UI.ViewModels
                 BeginClose(LastInput);
             });
             DisplaySettingsChanged = new RelayCommand(() => BeginClose(InputType.Command));
+
+            _mh = new MouseHook();
+            _mh.MouseWheelEvent += OnMouseWheelEvent;
+        }
+
+        public void UpdateWindowPos(double top, double left, double height, double width)
+        {
+            _winRect = new Rect(left, top, width, height);
         }
 
         private void OnDeBounceTimerTick(object sender, EventArgs e)
@@ -305,12 +316,31 @@ namespace EarTrumpet.UI.ViewModels
             }
         }
 
+        private int OnMouseWheelEvent(object sender, System.Windows.Forms.MouseEventArgs e)
+        {
+            var existing = _mainViewModel.Default;
+            if (existing != null)
+            {
+                if (!_winRect.Contains(new Point(e.X, e.Y)))
+                {
+                    existing.IncrementVolume(Math.Sign(e.Delta) * 2);
+                    return -1;
+                }
+            }
+            return 0;
+        }
+
         public void BeginOpen(InputType inputType)
         {
             if (State == FlyoutViewState.Hidden)
             {
                 LastInput = inputType;
                 ChangeState(FlyoutViewState.Opening);
+            }
+
+            if (_settings.UseGlobalMouseWheelHook)
+            {
+                _mh.SetHook();
             }
         }
 
@@ -325,6 +355,8 @@ namespace EarTrumpet.UI.ViewModels
             {
                 _closedDuringOpen = true;
             }
+
+            _mh.UnHook();
         }
 
         public void OpenFlyout(InputType inputType)

--- a/EarTrumpet/UI/ViewModels/IFlyoutViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/IFlyoutViewModel.cs
@@ -12,5 +12,6 @@ namespace EarTrumpet.UI.ViewModels
         event EventHandler<object> WindowSizeInvalidated;
 
         void ChangeState(FlyoutViewState state);
+        void UpdateWindowPos(double top, double left, double height, double width);
     }
 }

--- a/EarTrumpet/UI/Views/FlyoutWindow.xaml.cs
+++ b/EarTrumpet/UI/Views/FlyoutWindow.xaml.cs
@@ -178,33 +178,29 @@ namespace EarTrumpet.UI.Views
                 flyoutHeight = workingAreaHeight;
             }
 
+            double top = 0;
+            double left = 0;
             switch (taskbar.Location)
             {
                 case WindowsTaskbar.Position.Left:
-                    this.SetWindowPos(adjustedWorkingAreaBottom - flyoutHeight,
-                              adjustedWorkingAreaLeft,
-                              flyoutHeight,
-                              flyoutWidth);
+                    top = adjustedWorkingAreaBottom - flyoutHeight;
+                    left = adjustedWorkingAreaLeft;
                     break;
                 case WindowsTaskbar.Position.Right:
-                    this.SetWindowPos(adjustedWorkingAreaBottom - flyoutHeight,
-                              adjustedWorkingAreaRight - flyoutWidth,
-                              flyoutHeight,
-                              flyoutWidth);
+                    top = adjustedWorkingAreaBottom - flyoutHeight;
+                    left = adjustedWorkingAreaRight - flyoutWidth;
                     break;
                 case WindowsTaskbar.Position.Top:
-                    this.SetWindowPos(adjustedWorkingAreaTop + xOffset,
-                              FlowDirection == FlowDirection.LeftToRight ? adjustedWorkingAreaRight - flyoutWidth - xOffset : adjustedWorkingAreaLeft + xOffset,
-                              flyoutHeight,
-                              flyoutWidth);
+                    top = adjustedWorkingAreaTop + xOffset;
+                    left = FlowDirection == FlowDirection.LeftToRight ? adjustedWorkingAreaRight - flyoutWidth - xOffset : adjustedWorkingAreaLeft + xOffset;
                     break;
                 case WindowsTaskbar.Position.Bottom:
-                    this.SetWindowPos(adjustedWorkingAreaBottom - flyoutHeight - yOffset,
-                              FlowDirection == FlowDirection.LeftToRight ? adjustedWorkingAreaRight - flyoutWidth - xOffset : adjustedWorkingAreaLeft + xOffset,
-                              flyoutHeight,
-                              flyoutWidth);
+                    top = adjustedWorkingAreaBottom - flyoutHeight - yOffset;
+                    left = FlowDirection == FlowDirection.LeftToRight ? adjustedWorkingAreaRight - flyoutWidth - xOffset : adjustedWorkingAreaLeft + xOffset;
                     break;
             }
+            this.SetWindowPos(top, left, flyoutHeight, flyoutWidth);
+            _viewModel.UpdateWindowPos(top, left, flyoutHeight, flyoutWidth);
         }
 
         private void EnableAcrylicIfApplicable(WindowsTaskbar.State taskbar)

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -164,6 +164,9 @@
         <DataTemplate DataType="{x:Type vm:EarTrumpetMouseSettingsPageViewModel}">
             <StackPanel Orientation="Vertical">
                 <CheckBox HorizontalAlignment="Left"
+                          Content="{x:Static resx:Resources.SettingsUseScrollWheelInTray}"
+                          IsChecked="{Binding UseScrollWheelInTray, Mode=TwoWay}" />
+                <CheckBox HorizontalAlignment="Left"
                           Content="{x:Static resx:Resources.SettingsUseGlobalMouseWheelHook}"
                           IsChecked="{Binding UseGlobalMouseWheelHook, Mode=TwoWay}" />
             </StackPanel>

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -161,6 +161,13 @@
                 </Grid>
             </StackPanel>
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:EarTrumpetMouseSettingsPageViewModel}">
+            <StackPanel Orientation="Vertical">
+                <CheckBox HorizontalAlignment="Left"
+                          Content="{x:Static resx:Resources.SettingsUseGlobalMouseWheelHook}"
+                          IsChecked="{Binding UseGlobalMouseWheelHook, Mode=TwoWay}" />
+            </StackPanel>
+        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:EarTrumpetLegacySettingsPageViewModel}">
             <StackPanel Orientation="Vertical">
                 <CheckBox HorizontalAlignment="Left"


### PR DESCRIPTION
This PR adds "Extra settings" page with setting "Scroll anywhere to change volume when EarTrumpet is open". When it's turned on it will allow user to change system volume with mouse scroll when cursor isn't over the EarTrumpet window, just like regular volume control in Windows 10.

Discussion #658.
Issue #208.

![image](https://user-images.githubusercontent.com/8844478/171012636-ab4556d0-0108-440f-8e91-9fc1b85f062d.png)
