### PR TITLE
Improve flyout entrace animation

### DIFF
--- a/EarTrumpet/Interop/Helpers/WindowsTaskbar.cs
+++ b/EarTrumpet/Interop/Helpers/WindowsTaskbar.cs
@@ -13,6 +13,11 @@ namespace EarTrumpet.Interop.Helpers
             public RECT Size;
             public Screen ContainingScreen;
             public bool IsAutoHideEnabled;
+
+            public bool IsHorizontal
+            {
+                get { return Location == Position.Bottom || Location == Position.Top; }
+            }
         }
 
         // Must match AppBarEdge enum
@@ -74,6 +79,6 @@ namespace EarTrumpet.Interop.Helpers
             }
         }
 
-        private static IntPtr GetHwnd() => User32.FindWindow("Shell_TrayWnd", null);
+        public static IntPtr GetHwnd() => User32.FindWindow("Shell_TrayWnd", null);
     }
 }

--- a/EarTrumpet/UI/Helpers/WindowAnimationLibrary.cs
+++ b/EarTrumpet/UI/Helpers/WindowAnimationLibrary.cs
@@ -280,18 +280,5 @@ namespace EarTrumpet.UI.Helpers
         {
             User32.SetForegroundWindow(WindowsTaskbar.GetHwnd());
         }
-
-        public static double GetPrimaryScreenDPI()
-        {
-            int resHeight = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Height;
-            double actualHeight = SystemParameters.PrimaryScreenHeight;
-            double dpi = resHeight / actualHeight;
-            return dpi;
-        }
     }
 }
-
-
-
-
-

--- a/EarTrumpet/UI/Helpers/WindowAnimationLibrary.cs
+++ b/EarTrumpet/UI/Helpers/WindowAnimationLibrary.cs
@@ -1,5 +1,6 @@
 ﻿using EarTrumpet.DataModel;
 using EarTrumpet.Extensions;
+using EarTrumpet.Interop;
 using EarTrumpet.Interop.Helpers;
 using System;
 using System.Windows;
@@ -17,11 +18,13 @@ namespace EarTrumpet.UI.Helpers
             {
                 window.Topmost = true;
                 window.Focus();
+                User32.SetForegroundWindow(window.GetHandle());
                 completed();
             });
 
             window.Topmost = false;
             window.Activate();
+            BringTaskbarToFront();
 
             if (!SystemParameters.MenuAnimation)
             {
@@ -32,43 +35,45 @@ namespace EarTrumpet.UI.Helpers
 
             var moveAnimation = new DoubleAnimation
             {
-                Duration = new Duration(TimeSpan.FromMilliseconds(266)),
+                Duration = new Duration(TimeSpan.FromMilliseconds(130)),
                 FillBehavior = FillBehavior.Stop,
-                EasingFunction = new ExponentialEase { EasingMode = EasingMode.EaseOut }
+                EasingFunction = new QuinticEase { EasingMode = EasingMode.EaseOut }
             };
 
             var fadeAnimation = new DoubleAnimation
             {
-                Duration = new Duration(TimeSpan.FromMilliseconds(266)),
+                Duration = new Duration(TimeSpan.FromMilliseconds(140)),
                 FillBehavior = FillBehavior.Stop,
-                EasingFunction = new ExponentialEase { EasingMode = EasingMode.EaseOut },
-                From = 0.5,
+                EasingFunction = new QuinticEase { EasingMode = EasingMode.EaseOut },
+                From = 0.8,
                 To = 1
             };
             fadeAnimation.Completed += (s, e) => { window.Opacity = 1; };
             Storyboard.SetTarget(fadeAnimation, window);
             Storyboard.SetTargetProperty(fadeAnimation, new PropertyPath(Window.OpacityProperty));
 
+            double moveAnimationTo;
             switch (taskbar.Location)
             {
                 case WindowsTaskbar.Position.Left:
-                    moveAnimation.To = window.Left;
+                    moveAnimationTo = window.Left;
                     window.Left -= _animationOffset;
                     break;
                 case WindowsTaskbar.Position.Right:
-                    moveAnimation.To = window.Left;
+                    moveAnimationTo = window.Left;
                     window.Left += _animationOffset;
                     break;
                 case WindowsTaskbar.Position.Top:
-                    moveAnimation.To = window.Top;
+                    moveAnimationTo = window.Top;
                     window.Top -= _animationOffset;
                     break;
                 case WindowsTaskbar.Position.Bottom:
                 default:
-                    moveAnimation.To = window.Top;
+                    moveAnimationTo = window.Top;
                     window.Top += _animationOffset;
                     break;
             }
+            moveAnimation.To = moveAnimationTo;
 
             if (taskbar.Location == WindowsTaskbar.Position.Left || taskbar.Location == WindowsTaskbar.Position.Right)
             {
@@ -85,7 +90,7 @@ namespace EarTrumpet.UI.Helpers
 
             if (SystemSettings.IsTransparencyEnabled)
             {
-                window.Opacity = 0.5;
+                window.Opacity = 0.8;
             }
 
             window.Cloak(false);
@@ -99,7 +104,19 @@ namespace EarTrumpet.UI.Helpers
                 storyboard.Children.Add(fadeAnimation);
             }
 
+            storyboard.Completed += (s, e) =>
+            {
+                if (taskbar.IsHorizontal)
+                {
+                    window.Top = moveAnimationTo;
+                }
+                else
+                {
+                    window.Left = moveAnimationTo;
+                }
+            };
             storyboard.Completed += onCompleted;
+
             storyboard.Begin(window);
         }
 
@@ -123,14 +140,14 @@ namespace EarTrumpet.UI.Helpers
             {
                 Duration = new Duration(TimeSpan.FromMilliseconds(150)),
                 FillBehavior = FillBehavior.Stop,
-                EasingFunction = new ExponentialEase { EasingMode = EasingMode.EaseOut }
+                EasingFunction = new QuinticEase { EasingMode = EasingMode.EaseOut }
             };
 
             var fadeAnimation = new DoubleAnimation
             {
                 Duration = new Duration(TimeSpan.FromMilliseconds(150)),
                 FillBehavior = FillBehavior.Stop,
-                EasingFunction = new ExponentialEase { EasingMode = EasingMode.EaseOut },
+                EasingFunction = new QuinticEase { EasingMode = EasingMode.EaseOut },
                 From = 1,
                 To = 0.75,
             };
@@ -258,5 +275,23 @@ namespace EarTrumpet.UI.Helpers
 
             storyboard.Begin(window);
         }
+
+        public static void BringTaskbarToFront()
+        {
+            User32.SetForegroundWindow(WindowsTaskbar.GetHwnd());
+        }
+
+        public static double GetPrimaryScreenDPI()
+        {
+            int resHeight = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Height;
+            double actualHeight = SystemParameters.PrimaryScreenHeight;
+            double dpi = resHeight / actualHeight;
+            return dpi;
+        }
     }
 }
+
+
+
+
+

--- a/EarTrumpet/UI/ViewModels/FlyoutViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/FlyoutViewModel.cs
@@ -342,6 +342,10 @@ namespace EarTrumpet.UI.ViewModels
 
         public void OnDeactivated(object sender, EventArgs e)
         {
+            if (State == FlyoutViewState.Opening)
+            {
+                return;
+            }
             BeginClose(InputType.Command);
         }
 

--- a/EarTrumpet/UI/Views/FlyoutWindow.xaml.cs
+++ b/EarTrumpet/UI/Views/FlyoutWindow.xaml.cs
@@ -65,14 +65,14 @@ namespace EarTrumpet.UI.Views
 
                 case FlyoutViewState.Closing_Stage1:
                     DevicesList.FindVisualChild<DeviceView>()?.FocusAndRemoveFocusVisual();
-
+                
                     if (_viewModel.IsExpandingOrCollapsing)
                     {
                         WindowAnimationLibrary.BeginFlyoutExitanimation(this, () =>
                         {
                             this.Cloak();
                             AccentPolicyLibrary.DisableAcrylic(this);
-
+                
                             // Go directly to ViewState.Hidden to avoid the stage 2 hide delay (debounce for tray clicks),
                             // we want to show again immediately.
                             _viewModel.ChangeState(FlyoutViewState.Hidden);
@@ -83,7 +83,7 @@ namespace EarTrumpet.UI.Views
                         // No animation for normal exit.
                         this.Cloak();
                         AccentPolicyLibrary.DisableAcrylic(this);
-
+                
                         // Prevent de-queueing partially on show and showing stale adnorners.
                         this.WaitForKeyboardVisuals(() =>
                         {


### PR DESCRIPTION
This should mitigate the bug introduced in 19H1+ which slows down windows with acrylic effect applied using the undocumented API.

Also fixes an issue when flyout animation was showing above the taskbar when there are no active windows and the issue when flyout was overlapping the taskbar after animation end (often happens with fractional DPI scale factors, e.g. 125%).

Might need to test on Windows 11 to see how this affects the animation, as there is no acrylic bug in Windows 11.

| Before | After |
| ------------- | ------------- |
![](https://user-images.githubusercontent.com/51774833/171882970-eb98ec84-54c8-49a0-8b1c-cdaa875adab1.gif)  |  ![](https://user-images.githubusercontent.com/51774833/171884231-801bb5bb-2aed-4a44-8901-293f8f45e50a.gif)

Related issues: #391