### PR TITLE
Improved consistency with Light Theme

### DIFF
--- a/EarTrumpet/App.xaml
+++ b/EarTrumpet/App.xaml
@@ -34,8 +34,8 @@
                     </Theme:Ref>
                     <Theme:Ref Key="FlyoutThemeTrackRightBackground">
                         <Theme:Ref.Rules>
-                            <Theme:Rule On="UseAccentColor" Value="ControlLightSliderTrackBackgroundRest/0.5" />
-                            <Theme:Rule On="LightTheme" Value="ControlLightSliderTrackBackgroundRest" />
+                            <Theme:Rule On="UseAccentColor" Value="ControlLightBackgroundRest/0.5" />
+                            <Theme:Rule On="LightTheme" Value="#39000000" />
                             <Theme:Rule Value="#39FFFFFF" />
                         </Theme:Ref.Rules>
                     </Theme:Ref>
@@ -389,7 +389,7 @@
                                 <Track Name="PART_Track">
                                     <Track.DecreaseRepeatButton>
                                         <RepeatButton Name="SliderLeft"
-                                                      Theme:Brush.Foreground="SystemAccentLight1"
+                                                      Theme:Brush.Foreground="SystemAccent"
                                                       Command="Slider.DecreaseLarge"
                                                       Style="{StaticResource SliderButtonStyle}" />
                                     </Track.DecreaseRepeatButton>


### PR DESCRIPTION
EarTrumpet's light theme is not very consistent with native flyouts and is very difficult to see with particular accent colors.

| Before | After |
| ------------- | ------------- |
![](https://user-images.githubusercontent.com/51774833/171912425-145141f3-4e88-4faf-9472-80319ec79a5a.png)  |  ![](https://user-images.githubusercontent.com/51774833/171912433-2ea5b599-76d4-4320-872e-afb7ede78ce3.png)