### PR TITLE
Limit the scope of the acrylic bug mitigation to 19H1-W11

### DIFF
--- a/EarTrumpet/Extensions/OperatingSystemExtensions.cs
+++ b/EarTrumpet/Extensions/OperatingSystemExtensions.cs
@@ -7,6 +7,7 @@ namespace EarTrumpet.Extensions
         RS3 = 16299,
         RS4 = 17134,
         RS5_1809 = 17763,
+        Version19H1 = 18362,
         Version21H2 = 21390,
         Windows11 = 22000,
     }

--- a/EarTrumpet/UI/Themes/AcrylicBrush.cs
+++ b/EarTrumpet/UI/Themes/AcrylicBrush.cs
@@ -51,6 +51,11 @@ namespace EarTrumpet.UI.Themes
 
         private static void SuppressAryclic(Window window, DispatcherTimer timer)
         {
+            if (Environment.OSVersion.IsLessThan(OSVersions.Version19H1) || Environment.OSVersion.IsAtLeast(OSVersions.Windows11))
+            {
+                // The issue is present on 19H1 - Windows 11
+                return;
+            }
             if (window != null && (HwndSource)PresentationSource.FromVisual(window) != null)
             {
                 if (!timer.IsEnabled)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 ![EarTrumpet Screenshot](./Graphics/hero.gif)
 
+
+## Awards
+
+2022 Winner of the [Microsoft Store Community Choice Awards](https://blogs.windows.com/windowsdeveloper/2022/05/27/announcing-the-microsoft-store-app-awards-winners/#:~:text=open%20platform%20category) (Open Platform)
+> Windows is an open platform for innovation. We know that not every customer uses Windows in the same way — some want to modify different parts of the UI or make some features more accessible for them. These are the apps you said turn Windows into your Windows.
+
 ## Media coverage
 
 > [...] there are third-party solutions out there that do a much better job than what Windows offers by default. One such app is called EarTrumpet [...]

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Want to see what we were working on? Or help us test new features? [Install EarT
 - Windows 10 21H2 (November 2021 Update)
 - Windows 11
 
-## Known issues
-- SoundCloud audio cannot be adjusted ([#178](https://github.com/File-New-Project/EarTrumpet/issues/178))
-- Error: Windows cannot find "[...] EarTrumpet.exe". Make sure you typed the name correctly, and then try again ([#274](https://github.com/File-New-Project/EarTrumpet/issues/274))
-
 ## Credits
 - David Golden ([@GoldenTao](https://www.twitter.com/GoldenTao))
 - Rafael Rivera ([@WithinRafael](https://www.twitter.com/WithinRafael))
 - Dave Amenta ([@davux](https://www.twitter.com/davux))
 - [Contributors](https://github.com/File-New-Project/EarTrumpet/graphs/contributors)
+
+## Special thanks
+
+"[Horn](https://thenounproject.com/icon/horn-125731/)" icon by Artjom Korman from [the Noun Project](https://thenounproject.com/)


### PR DESCRIPTION
This limits the scope of the [acrylic bug](https://github.com/File-New-Project/EarTrumpet/issues/349) [mitigation](https://github.com/File-New-Project/EarTrumpet/commit/f3694825e09a2bde97a53afd96fe8ea205a71eb0) to Windows builds from 19H1 to Windows 11.

_Original PR: #1172_ 