### PR TITLE
Limit the scope of the acrylic bug mitigation to 19H1-W11

### DIFF
--- a/EarTrumpet/Extensions/OperatingSystemExtensions.cs
+++ b/EarTrumpet/Extensions/OperatingSystemExtensions.cs
@@ -7,6 +7,7 @@ namespace EarTrumpet.Extensions
         RS3 = 16299,
         RS4 = 17134,
         RS5_1809 = 17763,
+        Version19H1 = 18362,
         Version21H2 = 21390,
         Windows11 = 22000,
     }

--- a/EarTrumpet/UI/Themes/AcrylicBrush.cs
+++ b/EarTrumpet/UI/Themes/AcrylicBrush.cs
@@ -51,6 +51,11 @@ namespace EarTrumpet.UI.Themes
 
         private static void SuppressAryclic(Window window, DispatcherTimer timer)
         {
+            if (Environment.OSVersion.IsLessThan(OSVersions.Version19H1) || Environment.OSVersion.IsAtLeast(OSVersions.Windows11))
+            {
+                // The issue is present on 19H1 - Windows 11
+                return;
+            }
             if (window != null && (HwndSource)PresentationSource.FromVisual(window) != null)
             {
                 if (!timer.IsEnabled)


### PR DESCRIPTION
This limits the scope of the [acrylic bug](https://github.com/File-New-Project/EarTrumpet/issues/349) [mitigation](https://github.com/File-New-Project/EarTrumpet/commit/f3694825e09a2bde97a53afd96fe8ea205a71eb0) to Windows builds from 19H1 to Windows 11.

_Original PR: #1172, #1182_ 