### PR TITLE
Update tray icon tooltip on wheel scroll

### DIFF
--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -3,6 +3,7 @@ using EarTrumpet.Diagnosis;
 using EarTrumpet.Extensibility;
 using EarTrumpet.Extensibility.Hosting;
 using EarTrumpet.Extensions;
+using EarTrumpet.Interop;
 using EarTrumpet.Interop.Helpers;
 using EarTrumpet.UI.Helpers;
 using EarTrumpet.UI.ViewModels;
@@ -108,7 +109,14 @@ namespace EarTrumpet
             _trayIcon.PrimaryInvoke += (_, type) => _flyoutViewModel.OpenFlyout(type);
             _trayIcon.SecondaryInvoke += (_, args) => _trayIcon.ShowContextMenu(GetTrayContextMenuItems(), args.Point);
             _trayIcon.TertiaryInvoke += (_, __) => CollectionViewModel.Default?.ToggleMute.Execute(null);
-            _trayIcon.Scrolled += (_, wheelDelta) => CollectionViewModel.Default?.IncrementVolume(Math.Sign(wheelDelta) * 2);
+            _trayIcon.Scrolled += (_, wheelDelta) =>
+            {
+                CollectionViewModel.Default?.IncrementVolume(Math.Sign(wheelDelta) * 2);
+
+                IntPtr hWndTray = WindowsTaskbar.GetTrayToolbarWindowHwnd();
+                IntPtr hWndTooltip = User32.SendMessage(hWndTray, User32.TB_GETTOOLTIPS, IntPtr.Zero, IntPtr.Zero);
+                User32.SendMessage(hWndTooltip, User32.TTM_POPUP, IntPtr.Zero, IntPtr.Zero);
+            };
             _trayIcon.SetTooltip(CollectionViewModel.GetTrayToolTip());
             _trayIcon.IsVisible = true;
 

--- a/EarTrumpet/Interop/Helpers/WindowsTaskbar.cs
+++ b/EarTrumpet/Interop/Helpers/WindowsTaskbar.cs
@@ -80,5 +80,23 @@ namespace EarTrumpet.Interop.Helpers
         }
 
         public static IntPtr GetHwnd() => User32.FindWindow("Shell_TrayWnd", null);
+
+        public static IntPtr GetTrayToolbarWindowHwnd()
+        {
+            IntPtr hWnd = GetHwnd();
+            if (hWnd != IntPtr.Zero)
+            {
+                hWnd = User32.FindWindowEx(hWnd, IntPtr.Zero, "TrayNotifyWnd", IntPtr.Zero);
+                if (hWnd != IntPtr.Zero)
+                {
+                    hWnd = User32.FindWindowEx(hWnd, IntPtr.Zero, "SysPager", IntPtr.Zero);
+                    if (hWnd != IntPtr.Zero)
+                    {
+                        hWnd = User32.FindWindowEx(hWnd, IntPtr.Zero, "ToolbarWindow32", IntPtr.Zero);
+                    }
+                }
+            }
+            return hWnd;
+        }
     }
 }

--- a/EarTrumpet/Interop/User32.cs
+++ b/EarTrumpet/Interop/User32.cs
@@ -15,6 +15,8 @@ namespace EarTrumpet.Interop
         public const int WM_MBUTTONUP = 0x0208;
         public const int WM_SETTINGCHANGE = 0x001A;
         public const int SPI_SETWORKAREA = 0x002F;
+        public const int TTM_POPUP = 0x422;
+        public const int TB_GETTOOLTIPS = 0x423;
 
         public static uint MAKEWPARAM(ushort low, ushort high) => ((uint)high << 16) | low;
 
@@ -347,5 +349,8 @@ namespace EarTrumpet.Interop
         public static extern uint GetGuiResources(
                 IntPtr hProcess,
                 GR_FLAGS uiFlags);
+
+        [DllImport("user32.dll", PreserveSig = true)]
+        public static extern IntPtr SendMessage(IntPtr hWnd, int wMsg, IntPtr wParam, IntPtr lParam);
     }
 }


### PR DESCRIPTION
This obtains tooltip window handle by sending `TB_GETTOOLTIPS` message to the tray and requests it to update (i.e. sends `TTM_POPUP`, so it shows again), making it display the current volume level when adjusting using mouse wheel scroll

https://user-images.githubusercontent.com/51774833/215256566-ba2c5b0c-0b50-49a2-bc03-21fc6ce35192.mp4

