### PR TITLE
Update tray tooltip on device mute or default device change

### DIFF
--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -85,7 +85,7 @@ namespace EarTrumpet
 
             _trayIcon = new ShellNotifyIcon(new TaskbarIconSource(CollectionViewModel, Settings));
             Exit += (_, __) => _trayIcon.IsVisible = false;
-            CollectionViewModel.TrayPropertyChanged += () => _trayIcon.SetTooltip(CollectionViewModel.GetTrayToolTip());
+            CollectionViewModel.TrayPropertyChanged += () => UpdateTrayTooltip();
 
             _flyoutViewModel = new FlyoutViewModel(CollectionViewModel, () => _trayIcon.SetFocus(), Settings);
             FlyoutWindow = new FlyoutWindow(_flyoutViewModel);
@@ -136,8 +136,6 @@ namespace EarTrumpet
             {
                 CollectionViewModel.Default?.IncrementVolume(Math.Sign(wheelDelta) * 2);
             }
-
-            UpdateTrayTooltip();
         }
 
         private void DisplayFirstRunExperience()

--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -114,7 +114,7 @@ namespace EarTrumpet
             _trayIcon.PrimaryInvoke += (_, type) => _flyoutViewModel.OpenFlyout(type);
             _trayIcon.SecondaryInvoke += (_, args) => _trayIcon.ShowContextMenu(GetTrayContextMenuItems(), args.Point);
             _trayIcon.TertiaryInvoke += (_, __) => CollectionViewModel.Default?.ToggleMute.Execute(null);
-            _trayIcon.Scrolled += trayIconScrolled;
+            _trayIcon.Scrolled += TrayIconScrolled;
             _trayIcon.SetTooltip(CollectionViewModel.GetTrayToolTip());
             _trayIcon.IsVisible = true;
 
@@ -130,7 +130,7 @@ namespace EarTrumpet
             User32.SendMessage(hWndTooltip, User32.TTM_POPUP, IntPtr.Zero, IntPtr.Zero);
         }
 
-        private void trayIconScrolled(object _, int wheelDelta)
+        private void TrayIconScrolled(object _, int wheelDelta)
         {
             if (Settings.UseScrollWheelInTray && (!Settings.UseGlobalMouseWheelHook || _flyoutViewModel.State == FlyoutViewState.Hidden))
             {


### PR DESCRIPTION
It looks like this would be a better solution to consistently update the tooltip as the tooltip would be updated also when the volume is changed with hotkeys, the default device is muted/unmuted or when the default playback device is changed.