### PR TITLE
Feature/better volume stepping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## x.x.x.x
 - Fixed an issue where EarTrumpet tooltips were not updating in some scenarios (thanks @Tester798!)
 - Added setting to show the full mixer window on startup
+- Added support for adjusting volumes by 10% in one step from the flyout when the `Ctrl` key is pressed in combination with `Right`/`Left` or `+`/`-` (thanks @ryanspain)
 
 ## 2.3.0.0
 - Added setting to turn on/off ability to change volume with the scroll wheel anywhere (thanks @Tester798!)

--- a/EarTrumpet/UI/Views/AppItemView.xaml.cs
+++ b/EarTrumpet/UI/Views/AppItemView.xaml.cs
@@ -27,6 +27,25 @@ namespace EarTrumpet.UI.Views
 
         private void OnPreviewKeyDown(object sender, KeyEventArgs e)
         {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                switch (e.Key)
+                {
+                    case Key.Right:
+                    case Key.OemPlus:
+                        App.Volume += 10;
+                        e.Handled = true;
+                        break;
+                    case Key.Left:
+                    case Key.OemMinus:
+                        App.Volume -= 10;
+                        e.Handled = true;
+                        break;
+                }
+
+                return;
+            }
+
             switch (e.Key)
             {
                 case Key.M:

--- a/EarTrumpet/UI/Views/DeviceView.xaml.cs
+++ b/EarTrumpet/UI/Views/DeviceView.xaml.cs
@@ -52,6 +52,25 @@ namespace EarTrumpet.UI.Views
 
         private void OnPreviewKeyDown(object sender, KeyEventArgs e)
         {
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                switch (e.Key)
+                {
+                    case Key.Right:
+                    case Key.OemPlus:
+                        Device.Volume += 10;
+                        e.Handled = true;
+                        break;
+                    case Key.Left:
+                    case Key.OemMinus:
+                        Device.Volume -= 10;
+                        e.Handled = true;
+                        break;
+                }
+
+                return;
+            }
+
             switch (e.Key)
             {
                 case Key.M:


### PR DESCRIPTION
As per #677, this PR adds support for increasing/decreasing App or Device volumes by 10% in one step when the `Ctrl` key is pressed in combination with `Right`/'Left' (Or `+`/`-`).