### PR TITLE
Fix AudioDeviceManager.GetDefaultDevice to use eRole Parameter

### DIFF
--- a/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceManager.cs
+++ b/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceManager.cs
@@ -140,7 +140,7 @@ namespace EarTrumpet.DataModel.WindowsAudio.Internal
         {
             try
             {
-                var rawDevice = _enumerator.GetDefaultAudioEndpoint(Flow, ERole.eMultimedia);
+                var rawDevice = _enumerator.GetDefaultAudioEndpoint(Flow, eRole);
                 TryFind(rawDevice.GetId(), out var device);
                 return device;
             }


### PR DESCRIPTION
This is a fairly simple edit to correct the behaviour of AudioDeviceManager.GetDefaultDevice to use the eRole parameter passed rather than always return the eMultimedia device.

See issue #1494