### PR TITLE
Add translators to README

### DIFF
--- a/.github/workflows/translators.yml
+++ b/.github/workflows/translators.yml
@@ -1,0 +1,40 @@
+name: Update Translators List
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Run weekly on Sunday at 00:00
+  workflow_dispatch:
+
+jobs:
+  update-translators:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Fetch translators list from CrowdIn
+        id: fetch_translators
+        run: |
+          $headers = @{
+            "Authorization" = "Bearer ${{ secrets.CROWDIN_API_TOKEN }}"
+          }
+          $uri = "https://api.crowdin.com/api/v2/projects/407880/members"
+          $response = Invoke-RestMethod -Uri $uri -Headers $headers
+          echo "::set-output name=translators::$( $response.data )"
+        shell: pwsh
+
+      - name: Update README.md
+        run: |
+          $translators = "${{ steps.fetch_translators.outputs.translators }}" | ConvertFrom-Json
+          $translatorsHtml = $translators | ForEach-Object {
+            $avatarUrl = $_.data.avatarUrl
+            if (-not $avatarUrl) {
+              $avatarUrl = "https://ui-avatars.com/api/?name=$($_.data.fullName)"
+            }
+            "<img src=`"$avatarUrl`" width=`"60`" height=`"60`" alt=`"$($_.data.fullName)`">"
+          } | Sort-Object fullName | ForEach-Object { $_ + "`n" } -join ""
+          
+          $readmeContent = Get-Content -Path .\README.md -Raw
+          $updatedReadmeContent = $readmeContent -replace "<!-- translators -->", $translatorsHtml
+          Set-Content -Path .\README.md -Value $updatedReadmeContent
+        shell: pwsh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,9 @@ Before contributing code, we require the following workflow:
     ℹ It is OK for your PR to include a large number of commits. We will squash them on merge.
 
     ℹ It is also OK to create your PR as "[WIP]" before the implementation is done. This can be useful if you'd like to start the feedback process while you finish your implementation. State that this is the case in the initial PR comment.
+
+## Translation Workflow
+
+If you're interested in helping translate EarTrumpet, we'd love your contributions! Here's how you can get involved:
+
+1. Visit our project on CrowdIn at [https://crowdin.com/project/eartrumpet](https://crowdin.com/project/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
 
 <!-- sponsors --><a href="https://github.com/PykeMann"><img src="https://github.com/PykeMann.png" width="60px" alt="" /></a><a href="https://github.com/bastien09"><img src="https://github.com/bastien09.png" width="60px" alt="Bastien Auda" /></a><!-- sponsors -->
 
+## Translators
+
+<!-- translators -->
+
 ## Features
 
 * Visualize audio with multi-channel aware peaking


### PR DESCRIPTION
This pull request introduces automation for updating the `README.md` file with a list of localization contributors fetched from the CrowdIn API, and provides guidance for translators on how to get listed in the `README.md`.

- Adds a new GitHub Actions workflow file `.github/workflows/translators.yml` that:
  - Runs weekly to fetch the list of localization contributors using the CrowdIn API.
  - Updates the `README.md` file with the fetched list, placing translator avatars and names in the newly added "Translators" section.
  - Utilizes a secret `CROWDIN_API_TOKEN` for API authorization.
  - Sorts translators alphabetically by full name before updating the README.
- Modifies `README.md` to:
  - Include a placeholder comment `<!-- translators -->` where the list of translators will be dynamically inserted.
- Updates `CONTRIBUTING.md` to:
  - Add a new section titled `Translation Workflow` with guidance for translators on how to contribute translations and get listed in the `README.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/File-New-Project/EarTrumpet?shareId=c7690b5e-538e-4f6f-adf3-ea56e31a9688).