### PR TITLE
Workaround to File-New-Project/EarTrumpet#1305 (part of)

### DIFF
--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -118,6 +118,21 @@ public sealed partial class App : IDisposable
         // Initialize the FlyoutWindow last because its Show/Hide cycle will pump messages, causing UI frames
         // to be executed, breaking the assumption that startup is complete.
         FlyoutWindow.Initialize();
+
+        // listen for user session change
+        // When user come back after user switch, do some workaround for issue of losing audio sessions
+        SystemEvents.SessionSwitch += SystemEvents_SessionSwitch;
+        Exit += (_, __) => SystemEvents.SessionSwitch -= SystemEvents_SessionSwitch;
+    }
+
+    private void SystemEvents_SessionSwitch(object sender, SessionSwitchEventArgs e)
+    {
+        Trace.WriteLine($"Detected User Session Switch: {e.Reason}");
+        if (e.Reason == SessionSwitchReason.ConsoleConnect)
+        {
+            var devManager = WindowsAudioFactory.Create(AudioDeviceKind.Playback);
+            devManager.RefreshAllDevices();
+        }
     }
 
     private void CompleteStartup()

--- a/EarTrumpet/DataModel/Audio/IAudioDeviceManager.cs
+++ b/EarTrumpet/DataModel/Audio/IAudioDeviceManager.cs
@@ -12,4 +12,5 @@ public interface IAudioDeviceManager
     string Kind { get; }
     void UpdatePeakValues();
     void AddFilter(Func<ObservableCollection<IAudioDevice>, ObservableCollection<IAudioDevice>> filter);
+    void RefreshAllDevices();
 }


### PR DESCRIPTION
Try to workaround part of the issues in File-New-Project/EarTrumpet#1305 that applications disappear when users login back after user switching.

The workaround try to detect user re-connecting to its login session and do a refresh (delete and re-create) its device list.

Although it does not fix the root cause of the issue, I have been using this workaround for several months it does help to resolve my use case. Please consider accepting this when the real fix is not ready yet.