### PR TITLE
Support for StartAllBack multitaskbar notification area

### DIFF
--- a/EarTrumpet/Interop/Helpers/WindowsTaskbar.cs
+++ b/EarTrumpet/Interop/Helpers/WindowsTaskbar.cs
@@ -34,7 +34,7 @@ public sealed class WindowsTaskbar
         {
             unsafe
             {
-                return PInvoke.GetDpiForWindow(new HWND(GetHwnd()));
+                return PInvoke.GetDpiForShellUIComponent(SHELL_UI_COMPONENT.SHELL_UI_COMPONENT_NOTIFICATIONAREA);
             }
         }
     }
@@ -53,7 +53,7 @@ public sealed class WindowsTaskbar
                 var appBarData = new APPBARDATA
                 {
                     cbSize = (uint)Marshal.SizeOf(typeof(APPBARDATA)),
-                    hWnd = new HWND(hwnd)
+                    lParam = 0x42 // magic to get active taskbar rect with StartAllBack
                 };
 
                 // SHAppBarMessage: Understands Taskbar auto-hide
@@ -62,6 +62,7 @@ public sealed class WindowsTaskbar
                 {
                     state.Size = appBarData.rc;
                     state.Location = (Position)appBarData.uEdge;
+                    state.ContainingScreen = Screen.FromRectangle((System.Drawing.Rectangle)appBarData.rc);
                 }
                 else
                 {

--- a/EarTrumpet/NativeMethods.txt
+++ b/EarTrumpet/NativeMethods.txt
@@ -33,6 +33,7 @@ GET_GUI_RESOURCES_FLAGS
 GetApplicationUserModelId
 GetClassName
 GetCurrentProcess
+GetDpiForShellUIComponent
 GetDpiForSystem
 GetDpiForWindow
 GetForegroundWindow

--- a/EarTrumpet/UI/Views/FlyoutWindow.xaml.cs
+++ b/EarTrumpet/UI/Views/FlyoutWindow.xaml.cs
@@ -49,7 +49,11 @@ public partial class FlyoutWindow
 
                 Show();
                 EnableAcrylicIfApplicable(taskbar);
+                var prevDpi = this.DpiX();
                 PositionWindowRelativeToTaskbar(taskbar);
+                // Account for DPI changing due to SetWindowPos
+                if (this.DpiX() != prevDpi)
+                    PositionWindowRelativeToTaskbar(taskbar);
 
                 // Focus the first device if available.
                 DevicesList.FindVisualChild<DeviceView>()?.FocusAndRemoveFocusVisual();


### PR DESCRIPTION
StartAllBack provides support for per-taskbar notification area. Shell APIs would return active (last clicked) taskbar.

- Get active taskbar rect via ABM_GETTASKBARPOS with special flag; use that rect to get monitor instead of primary tray monitor
- Get taskbar DPI via proper API which would account for active / auto-hidden taskbar
- Readjust popup window position by repeating its calculation with new DPI to account for DPI changes

#1611