### PR TITLE
Fix scenarios where icon is blurry

### DIFF
--- a/EarTrumpet/Interop/Helpers/IconHelper.cs
+++ b/EarTrumpet/Interop/Helpers/IconHelper.cs
@@ -43,19 +43,12 @@ public class IconHelper
 
     public static Icon LoadIconResource(string path, int iconOrdinal, int cx, int cy)
     {
-        using var hModule = PInvoke.LoadLibraryEx(path, LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_AS_IMAGE_RESOURCE);
+        using var hModule = PInvoke.LoadLibraryEx(path, LOAD_LIBRARY_FLAGS.DONT_RESOLVE_DLL_REFERENCES);
         unsafe
         {
             var rawModuleHandle = new HMODULE(hModule.DangerousGetHandle().ToPointer());
-            var groupResInfo = PInvoke.FindResource(rawModuleHandle, new PCWSTR((char*)iconOrdinal), PInvoke.RT_GROUP_ICON);
-            var groupResData = PInvoke.LockResource(PInvoke.LoadResource(hModule, groupResInfo));
-            var iconId = PInvoke.LookupIconIdFromDirectoryEx((byte*)groupResData, true, cx, cy, IMAGE_FLAGS.LR_DEFAULTCOLOR);
-
-            var iconResInfo = PInvoke.FindResource(rawModuleHandle, new PCWSTR((char*)iconId), PInvoke.RT_ICON);
-            var iconResData = PInvoke.LockResource(PInvoke.LoadResource(hModule, iconResInfo));
-            var iconResSize = PInvoke.SizeofResource(hModule, iconResInfo);
-            var iconHandle = PInvoke.CreateIconFromResourceEx((byte*)iconResData, iconResSize, true, 0x00030000, cx, cy, IMAGE_FLAGS.LR_DEFAULTCOLOR);
-
+            HICON iconHandle;
+            PInvoke.LoadIconWithScaleDown(rawModuleHandle, new PCWSTR((char*)iconOrdinal), cx, cy, &iconHandle);
             return Icon.FromHandle(iconHandle).AsDisposableIcon();
         }
     }

--- a/EarTrumpet/NativeMethods.txt
+++ b/EarTrumpet/NativeMethods.txt
@@ -11,7 +11,6 @@ CallNextHookEx
 CloseHandle
 ClosePackageInfo
 CLSCTX
-CreateIconFromResourceEx
 DeleteObject
 DEVICE_STATE
 DEVPKEY_Device_DeviceDesc
@@ -24,7 +23,6 @@ DWMWINDOWATTRIBUTE
 EDataFlow
 ERole
 FindPackagesByPackageFamily
-FindResource
 FindWindow
 FindWindowEx
 FOLDERID_AppsFolder
@@ -78,12 +76,9 @@ ISubunit
 IsWow64Process2
 KNOWN_FOLDER_FLAG
 LOAD_LIBRARY_FLAGS
+LoadIconWithScaleDown
 LoadLibraryEx
-LoadResource
-LockResource
 LockSetForegroundWindow
-LookupIconIdFromDirectoryEx
-LookupIconIdFromDirectoryEx
 MAX_CLASS_NAME_LEN
 MMDeviceEnumerator
 MOUSE_STATE
@@ -147,7 +142,6 @@ SHLoadIndirectString
 SIGDN
 SIIGBF
 SIZE
-SizeofResource
 STGM
 SYSTEM_METRICS_INDEX
 SYSTEM_PARAMETERS_INFO_ACTION


### PR DESCRIPTION
- Using LoadIconWithScaleDown will ensure better-looking icon at non-standard DPI
- Notification area can update app icon itself for proper DPI if GetIconInfoEx will return proper module path; this doesn't work for LOAD_LIBRARY_AS_IMAGE_RESOURCE or LOAD_LIBRARY_AS_DATAFILE mapping unfortunately so use DONT_RESOLVE_DLL_REFERENCES

#495