### PR TITLE
Allow Windows to recolor icon automatically

### DIFF
--- a/EarTrumpet/Interop/Helpers/IconHelper.cs
+++ b/EarTrumpet/Interop/Helpers/IconHelper.cs
@@ -59,23 +59,4 @@ public class IconHelper
             return Icon.FromHandle(iconHandle).AsDisposableIcon();
         }
     }
-
-    public static Icon ColorIcon(Icon originalIcon, double fillPercent, System.Windows.Media.Color newColor)
-    {
-        using var bitmap = originalIcon.ToBitmap();
-        for (var y = 0; y < bitmap.Height; y++)
-        {
-            for (var x = 0; x < bitmap.Width * fillPercent; x++)
-            {
-                var pixel = bitmap.GetPixel(x, y);
-
-                if (pixel.R > 220)
-                {
-                    bitmap.SetPixel(x, y, Color.FromArgb(pixel.A, newColor.R, newColor.G, newColor.B));
-                }
-            }
-        }
-
-        return Icon.FromHandle(bitmap.GetHicon()).AsDisposableIcon();
-    }
 }

--- a/EarTrumpet/UI/Helpers/IShellNotifyIconSource.cs
+++ b/EarTrumpet/UI/Helpers/IShellNotifyIconSource.cs
@@ -6,6 +6,7 @@ public interface IShellNotifyIconSource
 {
     event Action<IShellNotifyIconSource> Changed;
     System.Drawing.Icon Current { get; }
+    bool IsWhiteIcon { get; }
     void OnMouseOverChanged(bool isMouseOver);
     void CheckForUpdate();
 }

--- a/EarTrumpet/UI/Helpers/ShellNotifyIcon.cs
+++ b/EarTrumpet/UI/Helpers/ShellNotifyIcon.cs
@@ -113,7 +113,8 @@ public sealed class ShellNotifyIcon : IDisposable
                      | NOTIFY_ICON_DATA_FLAGS.NIF_ICON
                      | NOTIFY_ICON_DATA_FLAGS.NIF_TIP
                      | NOTIFY_ICON_DATA_FLAGS.NIF_SHOWTIP
-                     | NOTIFY_ICON_DATA_FLAGS.NIF_GUID,
+                     | NOTIFY_ICON_DATA_FLAGS.NIF_GUID
+                     | (IconSource.IsWhiteIcon ? (NOTIFY_ICON_DATA_FLAGS)0x100 : 0),
             uCallbackMessage = WM_CALLBACKMOUSEMSG,
             hIcon = new HICON(IconSource.Current.Handle.ToPointer()),
             szTip = _text,


### PR DESCRIPTION
There's an undocumented flag for Shell_NotifyIcon which allows Windows 10+ to recolor white icons for light/high contrast theme.

Use it to simplify code.