### PR TITLE
Reimplementation of logarithmic volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Fixed the duplicate Windows Legacy > Volume Mixer entries that appear on Windows 11
 - Updated translations for Turkish, Russian, Croatian, German, Portuguese, Japanese, Swedish, Catalan, Korean, Hebrew, and Spanish
 - Fixed an issue with EarTrumpet Actions not recording packaged application IDs correctly
+- Added new and improved logarithmic volume implementation (thanks @Dwscdv3!)
+- Added logarithmic peak metering (thanks @Dwscdv3!)
+- Added adjustable logarithmic slider range (thanks @Dwscdv3!)
 
 ## 2.3.0.0
 - Added setting to turn on/off ability to change volume with the scroll wheel anywhere (thanks @Tester798!)

--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -81,19 +81,19 @@ public sealed partial class App : IDisposable
         _errorReporter = new ErrorReporter(Settings);
 
         if (SingleInstanceAppMutex.TakeExclusivity())
-    {
+        {
             Exit += (_, __) => SingleInstanceAppMutex.ReleaseExclusivity();
 
             try
-        {
+            {
                 NotifyOnMissingStartupPolicies();
                 ContinueStartup();
-        }
+            }
             catch (Exception ex) when (IsCriticalFontLoadFailure(ex))
             {
                 ErrorReporter.LogWarning(ex);
                 OnCriticalFontLoadFailure();
-    }
+            }
         }
         else
         {
@@ -126,13 +126,13 @@ public sealed partial class App : IDisposable
     }
 
     private void SystemEvents_SessionSwitch(object sender, SessionSwitchEventArgs e)
-        {
+    {
         Trace.WriteLine($"Detected User Session Switch: {e.Reason}");
         if (e.Reason == SessionSwitchReason.ConsoleConnect)
-            {
+        {
             var devManager = WindowsAudioFactory.Create(AudioDeviceKind.Playback);
             devManager.RefreshAllDevices();
-            }
+        }
     }
 
     private void CompleteStartup()
@@ -256,7 +256,7 @@ public sealed partial class App : IDisposable
                 "EnableUwpStartupTasks",
                 "SupportFullTrustStartupTasks",
                 "SupportUwpStartupTasks"
-        };
+            };
 
             foreach (var dword in dwords)
             {
@@ -267,7 +267,7 @@ public sealed partial class App : IDisposable
                 {
                     Trace.WriteLine($"Missing or invalid: {dword}");
                     return true;
-    }
+                }
             }
         }
         catch (Exception ex)
@@ -283,20 +283,20 @@ public sealed partial class App : IDisposable
         if (!IsAnyStartupPolicyMissing())
         {
             return;
-    }
+        }
 
         new Thread(() =>
-    {
+        {
             if (MessageBox.Show(
                 EarTrumpet.Properties.Resources.MissingPoliciesHelpText,
                 EarTrumpet.Properties.Resources.MissingPoliciesDialogHeaderText,
                 MessageBoxButton.OKCancel,
                 MessageBoxImage.Warning,
                 MessageBoxResult.OK) == MessageBoxResult.OK)
-        {
+            {
                 Trace.WriteLine($"App NotifyOnMissingStartupPolicies OK");
                 ProcessHelper.StartNoThrow("https://eartrumpet.app/jmp/fixstartup");
-        }
+            }
         }).Start();
     }
 
@@ -310,13 +310,13 @@ public sealed partial class App : IDisposable
         }));
 
         if (ret.Count == 0)
-            {
+        {
             ret.Add(new ContextMenuItem
             {
                 DisplayName = EarTrumpet.Properties.Resources.ContextMenuNoDevices,
                 IsEnabled = false,
             });
-            }
+        }
 
         ret.AddRange(
             [
@@ -393,7 +393,7 @@ public sealed partial class App : IDisposable
         if (!addon.IsInternal())
         {
             category.Pages.Add(new AddonAboutPageViewModel(addon));
-    }
+        }
         return category;
     }
 

--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -81,19 +81,19 @@ public sealed partial class App : IDisposable
         _errorReporter = new ErrorReporter(Settings);
 
         if (SingleInstanceAppMutex.TakeExclusivity())
-        {
+    {
             Exit += (_, __) => SingleInstanceAppMutex.ReleaseExclusivity();
 
             try
-            {
+        {
                 NotifyOnMissingStartupPolicies();
                 ContinueStartup();
-            }
+        }
             catch (Exception ex) when (IsCriticalFontLoadFailure(ex))
             {
                 ErrorReporter.LogWarning(ex);
                 OnCriticalFontLoadFailure();
-            }
+    }
         }
         else
         {
@@ -126,13 +126,13 @@ public sealed partial class App : IDisposable
     }
 
     private void SystemEvents_SessionSwitch(object sender, SessionSwitchEventArgs e)
-    {
+        {
         Trace.WriteLine($"Detected User Session Switch: {e.Reason}");
         if (e.Reason == SessionSwitchReason.ConsoleConnect)
-        {
+            {
             var devManager = WindowsAudioFactory.Create(AudioDeviceKind.Playback);
             devManager.RefreshAllDevices();
-        }
+            }
     }
 
     private void CompleteStartup()
@@ -151,6 +151,7 @@ public sealed partial class App : IDisposable
         Settings.AbsoluteVolumeUpHotkeyTyped += AbsoluteVolumeIncrement;
         Settings.AbsoluteVolumeDownHotkeyTyped += AbsoluteVolumeDecrement;
         Settings.RegisterHotkeys();
+        Settings.UseLogarithmicVolumeChanged += (_, __) => UpdateTrayTooltip();
 
         _trayIcon.PrimaryInvoke += (_, type) => _flyoutViewModel.OpenFlyout(type);
         _trayIcon.SecondaryInvoke += (_, args) => _trayIcon.ShowContextMenu(GetTrayContextMenuItems(), args.Point);
@@ -255,7 +256,7 @@ public sealed partial class App : IDisposable
                 "EnableUwpStartupTasks",
                 "SupportFullTrustStartupTasks",
                 "SupportUwpStartupTasks"
-            };
+        };
 
             foreach (var dword in dwords)
             {
@@ -266,7 +267,7 @@ public sealed partial class App : IDisposable
                 {
                     Trace.WriteLine($"Missing or invalid: {dword}");
                     return true;
-                }
+    }
             }
         }
         catch (Exception ex)
@@ -282,20 +283,20 @@ public sealed partial class App : IDisposable
         if (!IsAnyStartupPolicyMissing())
         {
             return;
-        }
+    }
 
         new Thread(() =>
-        {
+    {
             if (MessageBox.Show(
                 EarTrumpet.Properties.Resources.MissingPoliciesHelpText,
                 EarTrumpet.Properties.Resources.MissingPoliciesDialogHeaderText,
                 MessageBoxButton.OKCancel,
                 MessageBoxImage.Warning,
                 MessageBoxResult.OK) == MessageBoxResult.OK)
-            {
+        {
                 Trace.WriteLine($"App NotifyOnMissingStartupPolicies OK");
                 ProcessHelper.StartNoThrow("https://eartrumpet.app/jmp/fixstartup");
-            }
+        }
         }).Start();
     }
 
@@ -309,13 +310,13 @@ public sealed partial class App : IDisposable
         }));
 
         if (ret.Count == 0)
-        {
+            {
             ret.Add(new ContextMenuItem
             {
                 DisplayName = EarTrumpet.Properties.Resources.ContextMenuNoDevices,
                 IsEnabled = false,
             });
-        }
+            }
 
         ret.AddRange(
             [
@@ -392,7 +393,7 @@ public sealed partial class App : IDisposable
         if (!addon.IsInternal())
         {
             category.Pages.Add(new AddonAboutPageViewModel(addon));
-        }
+    }
         return category;
     }
 

--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -188,7 +188,8 @@ public sealed partial class App : IDisposable
     {
         if (Settings.UseScrollWheelInTray && (!Settings.UseGlobalMouseWheelHook || _flyoutViewModel.State == FlyoutViewState.Hidden))
         {
-            CollectionViewModel.Default?.IncrementVolume(Math.Sign(wheelDelta) * 2);
+            CollectionViewModel.Default?.IncrementVolume(
+                Math.Sign(wheelDelta) * (Settings.UseLogarithmicVolume ? 0.2f : 2.0f));
         }
     }
 

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -10,6 +10,7 @@ namespace EarTrumpet;
 public class AppSettings
 {
     public event EventHandler<bool> UseLegacyIconChanged;
+    public event EventHandler<bool> UseLogarithmicVolumeChanged;
     public event Action FlyoutHotkeyTyped;
     public event Action MixerHotkeyTyped;
     public event Action SettingsHotkeyTyped;
@@ -160,7 +161,21 @@ public class AppSettings
     public bool UseLogarithmicVolume
     {
         get => _settings.Get("UseLogarithmicVolume", false);
-        set => _settings.Set("UseLogarithmicVolume", value);
+        set
+        {
+            _settings.Set("UseLogarithmicVolume", value);
+            UseLogarithmicVolumeChanged?.Invoke(this, value);
+        }
+    }
+
+    public float LogarithmicVolumeMindB
+    {
+        get => _settings.Get("LogarithmicVolumeMindB", -40f);
+        set
+        {
+            _settings.Set("LogarithmicVolumeMindB", value);
+            UseLogarithmicVolumeChanged?.Invoke(this, UseLogarithmicVolume);
+        }
     }
 
     public WINDOWPLACEMENT? FullMixerWindowPlacement

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -168,12 +168,12 @@ public class AppSettings
         }
     }
 
-    public float LogarithmicVolumeMindB
+    public float LogarithmicVolumeMinDb
     {
-        get => _settings.Get("LogarithmicVolumeMindB", -40f);
+        get => _settings.Get("LogarithmicVolumeMinDb", -40f);
         set
         {
-            _settings.Set("LogarithmicVolumeMindB", value);
+            _settings.Set("LogarithmicVolumeMinDb", value);
             UseLogarithmicVolumeChanged?.Invoke(this, UseLogarithmicVolume);
         }
     }

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -10,7 +10,7 @@ namespace EarTrumpet;
 public class AppSettings
 {
     public event EventHandler<bool> UseLegacyIconChanged;
-    public event EventHandler<bool> UseLogarithmicVolumeChanged;
+    public event EventHandler<EventArgs> UseLogarithmicVolumeChanged;
     public event Action FlyoutHotkeyTyped;
     public event Action MixerHotkeyTyped;
     public event Action SettingsHotkeyTyped;
@@ -164,7 +164,7 @@ public class AppSettings
         set
         {
             _settings.Set("UseLogarithmicVolume", value);
-            UseLogarithmicVolumeChanged?.Invoke(this, value);
+            UseLogarithmicVolumeChanged?.Invoke(this, new EventArgs());
         }
     }
 
@@ -174,7 +174,7 @@ public class AppSettings
         set
         {
             _settings.Set("LogarithmicVolumeMinDb", value);
-            UseLogarithmicVolumeChanged?.Invoke(this, UseLogarithmicVolume);
+            UseLogarithmicVolumeChanged?.Invoke(this, new EventArgs());
         }
     }
 

--- a/EarTrumpet/DataModel/Audio/Mocks/AudioDevice.cs
+++ b/EarTrumpet/DataModel/Audio/Mocks/AudioDevice.cs
@@ -1,6 +1,5 @@
 ﻿using EarTrumpet.DataModel.WindowsAudio;
 using EarTrumpet.DataModel.WindowsAudio.Internal;
-using EarTrumpet.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -42,18 +41,9 @@ internal class AudioDevice : BindableBase, IAudioDevice, IAudioDeviceInternal, I
     private float _volume = 1;
     public float Volume
     {
-        get
-        {
-            return App.Settings.UseLogarithmicVolume ? _volume.ToDisplayVolume() : _volume;
-        }
-
+        get => _volume;
         set
         {
-            if (App.Settings.UseLogarithmicVolume)
-            {
-                value = value.ToLogVolume();
-            }
-
             if (_volume != value)
             {
                 _volume = value;

--- a/EarTrumpet/DataModel/Audio/Mocks/AudioDeviceSession.cs
+++ b/EarTrumpet/DataModel/Audio/Mocks/AudioDeviceSession.cs
@@ -51,16 +51,12 @@ internal class AudioDeviceSession : BindableBase, IAudioDeviceSessionInternal
     private float _volume = 1;
     public float Volume
     {
-        get
-        {
-            return App.Settings.UseLogarithmicVolume ? _volume.ToDisplayVolume() : _volume;
-        }
-
+        get => _volume;
         set
         {
             if (App.Settings.UseLogarithmicVolume)
             {
-                value = value.ToLogVolume();
+                value = value.LinearToLogNormalized();
             }
 
             if (_volume != value)

--- a/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDevice.cs
+++ b/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDevice.cs
@@ -138,7 +138,7 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
                     value = value.Bound(_deviceVolumeMinDb, _deviceVolumeMaxDb);
                     _volume = value;
                     _deviceVolume.SetMasterVolumeLevel(value, Guid.Empty);
-                    IsMuted = false; // Mute is equals to -∞ in dB, so we always unmute when setting volume.
+                    IsMuted = value <= App.Settings.LogarithmicVolumeMinDb;
                 }
                 else
                 {

--- a/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDevice.cs
+++ b/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDevice.cs
@@ -25,8 +25,8 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
     private readonly WeakReference<IAudioDeviceManager> _deviceManager;
     private readonly string _id;
     private readonly AudioDeviceChannelCollection _channels;
-    private readonly float _deviceVolumeMindB;
-    private readonly float _deviceVolumeMaxdB;
+    private readonly float _deviceVolumeMinDb;
+    private readonly float _deviceVolumeMaxDb;
     private IMMDevice _device;
     private string _displayName;
     private string _iconPath;
@@ -62,7 +62,7 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
                 _deviceVolume.GetMasterVolumeLevelScalar(out _volume);
             }
             _deviceVolume.GetMute(out var isMuted);
-            _deviceVolume.GetVolumeRange(out _deviceVolumeMindB, out _deviceVolumeMaxdB, out _);
+            _deviceVolume.GetVolumeRange(out _deviceVolumeMinDb, out _deviceVolumeMaxDb, out _);
             _isMuted = isMuted;
             _isRegistered = true;
             _meter = device.Activate<IAudioMeterInformation>();
@@ -134,8 +134,8 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
             {
                 if (App.Settings.UseLogarithmicVolume)
                 {
-                    value = value.Bound(App.Settings.LogarithmicVolumeMindB, 0);
-                    value = value.Bound(_deviceVolumeMindB, _deviceVolumeMaxdB);
+                    value = value.Bound(App.Settings.LogarithmicVolumeMinDb, 0);
+                    value = value.Bound(_deviceVolumeMinDb, _deviceVolumeMaxDb);
                     _volume = value;
                     _deviceVolume.SetMasterVolumeLevel(value, Guid.Empty);
                     IsMuted = false; // Mute is equals to -∞ in dB, so we always unmute when setting volume.

--- a/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDevice.cs
+++ b/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDevice.cs
@@ -25,6 +25,8 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
     private readonly WeakReference<IAudioDeviceManager> _deviceManager;
     private readonly string _id;
     private readonly AudioDeviceChannelCollection _channels;
+    private readonly float _deviceVolumeMindB;
+    private readonly float _deviceVolumeMaxdB;
     private IMMDevice _device;
     private string _displayName;
     private string _iconPath;
@@ -51,8 +53,16 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
         {
             _deviceVolume = device.Activate<IAudioEndpointVolume>();
             _deviceVolume.RegisterControlChangeNotify(this);
-            _deviceVolume.GetMasterVolumeLevelScalar(out _volume);
+            if (App.Settings.UseLogarithmicVolume)
+            {
+                _deviceVolume.GetMasterVolumeLevel(out _volume);
+            }
+            else
+            {
+                _deviceVolume.GetMasterVolumeLevelScalar(out _volume);
+            }
             _deviceVolume.GetMute(out var isMuted);
+            _deviceVolume.GetVolumeRange(out _deviceVolumeMindB, out _deviceVolumeMaxdB, out _);
             _isMuted = isMuted;
             _isRegistered = true;
             _meter = device.Activate<IAudioMeterInformation>();
@@ -67,6 +77,19 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
         }
 
         ReadProperties();
+
+        App.Settings.UseLogarithmicVolumeChanged += (sender, args) =>
+        {
+            if (App.Settings.UseLogarithmicVolume)
+            {
+                _deviceVolume.GetMasterVolumeLevel(out _volume);
+            }
+            else
+            {
+                _deviceVolume.GetMasterVolumeLevelScalar(out _volume);
+            }
+            RaisePropertyChanged(nameof(Volume));
+        };
     }
 
     ~AudioDevice()
@@ -87,6 +110,10 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
     public unsafe void OnNotify(AUDIO_VOLUME_NOTIFICATION_DATA* pNotify)
     {
         _volume = (*pNotify).fMasterVolume;
+        if (App.Settings.UseLogarithmicVolume)
+        {
+            _deviceVolume.GetMasterVolumeLevel(out _volume);
+        }
         _isMuted = (*pNotify).bMuted != 0;
 
         _channels.OnNotify((nint)pNotify, *pNotify);
@@ -100,29 +127,31 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
 
     public float Volume
     {
-        get => App.Settings.UseLogarithmicVolume ? _volume.ToDisplayVolume() : _volume;
+        get => _volume;
         set
         {
-            value = value.Bound(0, 1f);
-
-            if (App.Settings.UseLogarithmicVolume)
+            try
             {
-                value = value.ToLogVolume();
-            }
-
-            if (_volume != value)
-            {
-                try
+                if (App.Settings.UseLogarithmicVolume)
                 {
+                    value = value.Bound(App.Settings.LogarithmicVolumeMindB, 0);
+                    value = value.Bound(_deviceVolumeMindB, _deviceVolumeMaxdB);
+                    _volume = value;
+                    _deviceVolume.SetMasterVolumeLevel(value, Guid.Empty);
+                    IsMuted = false; // Mute is equals to -∞ in dB, so we always unmute when setting volume.
+                }
+                else
+                {
+                    value = value.Bound(0, 1f);
                     _volume = value;
                     _deviceVolume.SetMasterVolumeLevelScalar(value, Guid.Empty);
+                    IsMuted = _volume.ToVolumeInt() == 0;
                 }
-                catch (Exception ex) when (ex.Is(HRESULT.AUDCLNT_E_DEVICE_INVALIDATED))
-                {
-                    // Expected in some cases.
-                }
-
-                IsMuted = App.Settings.UseLogarithmicVolume ? _volume <= (1 / 100f).ToLogVolume() : _volume.ToVolumeInt() == 0;
+            }
+            catch (Exception ex) when (ex.Is(HRESULT.AUDCLNT_E_DEVICE_INVALIDATED))
+            {
+                // Expected in some cases.
+                // Known: when the master volume in dB is beyond device capabilities
             }
         }
     }
@@ -176,8 +205,16 @@ public class AudioDevice : BindableBase, IAudioEndpointVolumeCallback, IAudioDev
     public void UpdatePeakValue()
     {
         var newValues = Helpers.ReadPeakValues(_meter);
-        PeakValue1 = newValues[0];
-        PeakValue2 = newValues[1];
+        if (App.Settings.UseLogarithmicVolume)
+        {
+            PeakValue1 = newValues[0].LinearToLogNormalized();
+            PeakValue2 = newValues[1].LinearToLogNormalized();
+        }
+        else
+        {
+            PeakValue1 = newValues[0];
+            PeakValue2 = newValues[1];
+        }
 
         foreach(var session in _sessions.Sessions.ToArray())
         {

--- a/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceChannel.cs
+++ b/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceChannel.cs
@@ -14,7 +14,14 @@ internal class AudioDeviceChannel : BindableBase, INotifyPropertyChanged, IAudio
     {
         _index = index;
         _deviceVolume = deviceVolume;
-        _deviceVolume.GetChannelVolumeLevelScalar(index, out _level);
+        if (App.Settings.UseLogarithmicVolume)
+        {
+            _deviceVolume.GetChannelVolumeLevel(index, out _level);
+        }
+        else
+        {
+            _deviceVolume.GetChannelVolumeLevelScalar(index, out _level);
+        }
     }
 
     public float Level
@@ -25,7 +32,17 @@ internal class AudioDeviceChannel : BindableBase, INotifyPropertyChanged, IAudio
             if (_level != value)
             {
                 var context = Guid.Empty;
-                unsafe { _deviceVolume.SetChannelVolumeLevelScalar(_index, value, &context); }
+                unsafe
+                {
+                    if (App.Settings.UseLogarithmicVolume)
+                    {
+                        _deviceVolume.SetChannelVolumeLevel(_index, value, &context);
+                    }
+                    else
+                    {
+                        _deviceVolume.SetChannelVolumeLevelScalar(_index, value, &context);
+                    }
+                }
 
                 _level = value;
                 RaisePropertyChanged(nameof(Level));

--- a/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceSession.cs
+++ b/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceSession.cs
@@ -46,7 +46,7 @@ internal class AudioDeviceSession : BindableBase, IAudioSessionEvents, IAudioDev
                     // We must convert manually here because sessions use linear volume.
                     _simpleVolume.SetMasterVolume(value.LogToLinear(), Guid.Empty);
                     _volume = value;
-                    IsMuted = false; // Mute is equals to -∞ in dB, so we always unmute when setting volume.
+                    IsMuted = value <= App.Settings.LogarithmicVolumeMinDb;
                 }
                 else
                 {

--- a/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceSession.cs
+++ b/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceSession.cs
@@ -42,7 +42,7 @@ internal class AudioDeviceSession : BindableBase, IAudioSessionEvents, IAudioDev
             {
                 if (App.Settings.UseLogarithmicVolume)
                 {
-                    value = value.Bound(App.Settings.LogarithmicVolumeMindB, 0);
+                    value = value.Bound(App.Settings.LogarithmicVolumeMinDb, 0);
                     // We must convert manually here because sessions use linear volume.
                     _simpleVolume.SetMasterVolume(value.LogToLinear(), Guid.Empty);
                     _volume = value;

--- a/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceSession.cs
+++ b/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceSession.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Threading;
 using Windows.Win32;
 using Windows.Win32.Media.Audio;
@@ -193,8 +194,15 @@ internal class AudioDeviceSession : BindableBase, IAudioSessionEvents, IAudioDev
             }
         }
 
-        // Potential memory leak: this class is not IDisposable, so we cannot unregister the event.
-        App.Settings.UseLogarithmicVolumeChanged += (sender, args) => RaisePropertyChanged(nameof(Volume));
+        WeakEventManager<AppSettings, EventArgs>.AddHandler(
+            App.Settings,
+            nameof(AppSettings.UseLogarithmicVolumeChanged),
+            UseLogarithmicVolumeChangedHandler);
+    }
+
+    private void UseLogarithmicVolumeChangedHandler(object sender, EventArgs e)
+    {
+        RaisePropertyChanged(nameof(Volume));
     }
 
     ~AudioDeviceSession()

--- a/EarTrumpet/Extensions/FloatExtensions.cs
+++ b/EarTrumpet/Extensions/FloatExtensions.cs
@@ -4,8 +4,6 @@ namespace EarTrumpet.Extensions;
 
 public static class FloatExtensions
 {
-    private const float CURVE_FACTOR = 5.757f;
-
     public static int ToVolumeInt(this float val)
     {
         return Convert.ToInt32(Math.Round(val * 100, MidpointRounding.AwayFromZero));
@@ -16,13 +14,13 @@ public static class FloatExtensions
         return Math.Max(min, Math.Min(max, val));
     }
 
-    public static float ToLogVolume(this float val)
-    {
-        return ((float)(Math.Exp(CURVE_FACTOR * val) / Math.Exp(CURVE_FACTOR))).Bound(0, 1f);
-    }
+    public static float LinearToLog(this float val) => (float)(20 * Math.Log10(val));
 
-    public static float ToDisplayVolume(this float val)
-    {
-        return ((float)(Math.Log(val * Math.Exp(CURVE_FACTOR)) / CURVE_FACTOR)).Bound(0, 1f);
-    }
+    public static float LinearToLogNormalized(this float val) =>
+        val == 0
+            ? 0
+            : ((float)(20 * Math.Log10(val) / -App.Settings.LogarithmicVolumeMindB + 1))
+                .Bound(0, 1f);
+
+    public static float LogToLinear(this float val) => (float)Math.Pow(10, val / 20);
 }

--- a/EarTrumpet/Extensions/FloatExtensions.cs
+++ b/EarTrumpet/Extensions/FloatExtensions.cs
@@ -19,7 +19,7 @@ public static class FloatExtensions
     public static float LinearToLogNormalized(this float val) =>
         val == 0
             ? 0
-            : ((float)(20 * Math.Log10(val) / -App.Settings.LogarithmicVolumeMindB + 1))
+            : ((float)(20 * Math.Log10(val) / -App.Settings.LogarithmicVolumeMinDb + 1))
                 .Bound(0, 1f);
 
     public static float LogToLinear(this float val) => (float)Math.Pow(10, val / 20);

--- a/EarTrumpet/Properties/Resources.Designer.cs
+++ b/EarTrumpet/Properties/Resources.Designer.cs
@@ -1406,6 +1406,15 @@ namespace EarTrumpet.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Logarithmic scale minimum.
+        /// </summary>
+        public static string SettingsLogarithmicScaleMinimum {
+            get {
+                return ResourceManager.GetString("SettingsLogarithmicScaleMinimum", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open Taskbar flyout.
         /// </summary>
         public static string SettingsOpenEarTrumpetText {

--- a/EarTrumpet/Properties/Resources.resx
+++ b/EarTrumpet/Properties/Resources.resx
@@ -676,4 +676,7 @@ Open [https://eartrumpet.app/jmp/fixstartup] to resolve this?</value>
   <data name="SettingsShowFullMixerWindowOnStartup" xml:space="preserve">
     <value>Show full mixer window on startup</value>
   </data>
+  <data name="SettingsLogarithmicScaleMinimum" xml:space="preserve">
+    <value>Logarithmic scale minimum</value>
+  </data>
 </root>

--- a/EarTrumpet/UI/Controls/VolumeSlider.cs
+++ b/EarTrumpet/UI/Controls/VolumeSlider.cs
@@ -41,11 +41,11 @@ public class VolumeSlider : Slider
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
 
-        UseLogarithmicVolumeChangedHandler(null, App.Settings.UseLogarithmicVolume);
+        UseLogarithmicVolumeChangedHandler(null, new EventArgs());
         App.Settings.UseLogarithmicVolumeChanged += UseLogarithmicVolumeChangedHandler;
     }
 
-    private void UseLogarithmicVolumeChangedHandler(object sender, bool value)
+    private void UseLogarithmicVolumeChangedHandler(object sender, EventArgs e)
     {
         UpdateVolumeRange();
         SizeOrVolumeOrPeakValueChanged();

--- a/EarTrumpet/UI/Controls/VolumeSlider.cs
+++ b/EarTrumpet/UI/Controls/VolumeSlider.cs
@@ -39,6 +39,16 @@ public class VolumeSlider : Slider
         MouseMove += OnMouseMove;
         MouseWheel += OnMouseWheel;
         Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+
+        UseLogarithmicVolumeChangedHandler(null, App.Settings.UseLogarithmicVolume);
+        App.Settings.UseLogarithmicVolumeChanged += UseLogarithmicVolumeChangedHandler;
+    }
+
+    private void UseLogarithmicVolumeChangedHandler(object sender, bool value)
+    {
+        UpdateVolumeRange();
+        SizeOrVolumeOrPeakValueChanged();
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -46,6 +56,11 @@ public class VolumeSlider : Slider
         _thumb = (Thumb)GetTemplateChild("SliderThumb");
         _peakMeter1 = (Border)GetTemplateChild("PeakMeter1");
         _peakMeter2 = (Border)GetTemplateChild("PeakMeter2");
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        App.Settings.UseLogarithmicVolumeChanged -= UseLogarithmicVolumeChangedHandler;
     }
 
     protected override Size ArrangeOverride(Size arrangeBounds)
@@ -60,16 +75,46 @@ public class VolumeSlider : Slider
         ((VolumeSlider)d).SizeOrVolumeOrPeakValueChanged();
     }
 
+    private void UpdateVolumeRange()
+    {
+        if (App.Settings.UseLogarithmicVolume)
+        {
+            Minimum = App.Settings.LogarithmicVolumeMindB;
+            Maximum = 0f;
+            TickFrequency = 0.1;
+        }
+        else
+        {
+            Minimum = 0f;
+            Maximum = 100f;
+            TickFrequency = 1;
+        }
+    }
+
     private void SizeOrVolumeOrPeakValueChanged()
     {
         if (_peakMeter1 != null)
         {
-            _peakMeter1.Width = Math.Max(0, (ActualWidth - _thumb.ActualWidth) * PeakValue1 * (Value / 100f));
+            if (App.Settings.UseLogarithmicVolume)
+            {
+                _peakMeter1.Width = Math.Max(0, (ActualWidth - _thumb.ActualWidth) * (PeakValue1 - Value / Minimum));
+            }
+            else
+            {
+                _peakMeter1.Width = Math.Max(0, (ActualWidth - _thumb.ActualWidth) * PeakValue1 * (Value / 100f));
+            }
         }
 
         if (_peakMeter2 != null)
         {
-            _peakMeter2.Width = Math.Max(0, (ActualWidth - _thumb.ActualWidth) * PeakValue2 * (Value / 100f));
+            if (App.Settings.UseLogarithmicVolume)
+            {
+                _peakMeter2.Width = Math.Max(0, (ActualWidth - _thumb.ActualWidth) * (PeakValue2 - Value / Minimum));
+            }
+            else
+            {
+                _peakMeter2.Width = Math.Max(0, (ActualWidth - _thumb.ActualWidth) * PeakValue2 * (Value / 100f));
+            }
         }
     }
 
@@ -145,7 +190,7 @@ public class VolumeSlider : Slider
 
     private void OnMouseWheel(object sender, MouseWheelEventArgs e)
     {
-        var amount = Math.Sign(e.Delta) * 2.0;
+        var amount = Math.Sign(e.Delta) * (App.Settings.UseLogarithmicVolume ? 0.2 : 2.0);
         ChangePositionByAmount(amount);
         e.Handled = true;
     }
@@ -153,7 +198,9 @@ public class VolumeSlider : Slider
     public void SetPositionByControlPoint(Point point)
     {
         var percent = point.X / ActualWidth;
-        Value = Bound((Maximum - Minimum) * percent);
+        Value = App.Settings.UseLogarithmicVolume
+            ? (percent - 1) * -App.Settings.LogarithmicVolumeMindB
+            : Bound((Maximum - Minimum) * percent);
     }
 
     public void ChangePositionByAmount(double amount)

--- a/EarTrumpet/UI/Controls/VolumeSlider.cs
+++ b/EarTrumpet/UI/Controls/VolumeSlider.cs
@@ -79,7 +79,7 @@ public class VolumeSlider : Slider
     {
         if (App.Settings.UseLogarithmicVolume)
         {
-            Minimum = App.Settings.LogarithmicVolumeMindB;
+            Minimum = App.Settings.LogarithmicVolumeMinDb;
             Maximum = 0f;
             TickFrequency = 0.1;
         }
@@ -199,7 +199,7 @@ public class VolumeSlider : Slider
     {
         var percent = point.X / ActualWidth;
         Value = App.Settings.UseLogarithmicVolume
-            ? (percent - 1) * -App.Settings.LogarithmicVolumeMindB
+            ? (percent - 1) * -App.Settings.LogarithmicVolumeMinDb
             : Bound((Maximum - Minimum) * percent);
     }
 

--- a/EarTrumpet/UI/Controls/VolumeSlider.cs
+++ b/EarTrumpet/UI/Controls/VolumeSlider.cs
@@ -199,7 +199,7 @@ public class VolumeSlider : Slider
     {
         var percent = point.X / ActualWidth;
         Value = App.Settings.UseLogarithmicVolume
-            ? (percent - 1) * -App.Settings.LogarithmicVolumeMinDb
+            ? Math.Round((percent - 1) * -App.Settings.LogarithmicVolumeMinDb, 1)
             : Bound((Maximum - Minimum) * percent);
     }
 

--- a/EarTrumpet/UI/Controls/VolumeSlider.cs
+++ b/EarTrumpet/UI/Controls/VolumeSlider.cs
@@ -199,8 +199,8 @@ public class VolumeSlider : Slider
     {
         var percent = point.X / ActualWidth;
         Value = App.Settings.UseLogarithmicVolume
-            ? Math.Round((percent - 1) * -App.Settings.LogarithmicVolumeMinDb, 1)
-            : Bound((Maximum - Minimum) * percent);
+            ? Math.Round(Minimum + percent * (Maximum - Minimum), 1)
+            : Bound(Minimum + (Maximum - Minimum) * percent);
     }
 
     public void ChangePositionByAmount(double amount)

--- a/EarTrumpet/UI/Converters/NegateConverter.cs
+++ b/EarTrumpet/UI/Converters/NegateConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Windows.Data;
+
+namespace EarTrumpet.UI.Converters
+{
+    public class NegateConverter : IValueConverter 
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is double d) return -d;
+            if (value is float f) return (double)-f;
+            if (value is int i) return (double)-i;
+            throw new NotImplementedException();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is double d) return -d;
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/EarTrumpet/UI/Converters/VolumeToStringConverter.cs
+++ b/EarTrumpet/UI/Converters/VolumeToStringConverter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Windows.Data;
+
+namespace EarTrumpet.UI.Converters;
+
+public class VolumeToStringConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+    {
+        if (value is float vol)
+        {
+            if (App.Settings.UseLogarithmicVolume)
+            {
+                // Special case for -0.0 display
+                if (vol >= -0.05)
+                {
+                    return "-0.0";
+                }
+                return $"{vol:0.0}";
+            }
+            return vol.ToString();
+        }
+        return "";
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EarTrumpet/UI/ViewModels/AudioSessionViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/AudioSessionViewModel.cs
@@ -44,10 +44,16 @@ public class AudioSessionViewModel : BindableBase
         set => _isAbsMuted = value;
     }
 
-    public int Volume
+    // For compatibility reasons, we use 0-100 for linear volume,
+    // and negative number for logarithmic volume.
+    public float Volume
     {
-        get => _stream.Volume.ToVolumeInt();
-        set => _stream.Volume = value/100f;
+        get => App.Settings.UseLogarithmicVolume
+            ? _stream.Volume
+            : _stream.Volume.ToVolumeInt();
+        set => _stream.Volume = App.Settings.UseLogarithmicVolume
+            ? value
+            : value / 100f;
     }
     public virtual float PeakValue1 => _stream.PeakValue1;
     public virtual float PeakValue2 => _stream.PeakValue2;

--- a/EarTrumpet/UI/ViewModels/DeviceCollectionViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/DeviceCollectionViewModel.cs
@@ -245,7 +245,10 @@ public class DeviceCollectionViewModel : BindableBase, IDisposable
     {
         if (Default != null)
         {
-            var stateText = Default.IsMuted ? Properties.Resources.MutedText : $"{Default.Volume}%";
+            var volumeText = App.Settings.UseLogarithmicVolume
+                ? $"{Default.Volume:0.0} dB"
+                : $"{Default.Volume}%";
+            var stateText = Default.IsMuted ? Properties.Resources.MutedText : volumeText;
             var prefixText = $"EarTrumpet: {stateText} - ";
             var deviceName = $"{Default.DeviceDescription} ({Default.EnumeratorName})";
 

--- a/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
@@ -136,21 +136,25 @@ public class DeviceViewModel : AudioSessionViewModel, IDeviceViewModel
             }
             else if (App.Settings.UseLogarithmicVolume)
             {
-                if (_device.Volume > -6.2f)
+                if (isOnWindows11)
                 {
-                    IconKind = DeviceIconKind.Bar3;
-                }
-                else if (_device.Volume > -16.6f)
-                {
-                    IconKind = DeviceIconKind.Bar2;
-                }
-                else if (_device.Volume > -96f)
-                {
-                    IconKind = DeviceIconKind.Bar1;
+                    IconKind = _device.Volume switch
+                    {
+                        >= - 6.1f => DeviceIconKind.Bar3,
+                        >= -16.5f => DeviceIconKind.Bar2,
+                        >  -96.0f => DeviceIconKind.Bar1,
+                        _         => DeviceIconKind.Bar0,
+                    };
                 }
                 else
                 {
-                    IconKind = DeviceIconKind.Bar0;
+                    IconKind = _device.Volume switch
+                    {
+                        >= - 6.4f => DeviceIconKind.Bar3,
+                        >= -17.0f => DeviceIconKind.Bar2,
+                        >  -96.0f => DeviceIconKind.Bar1,
+                        _         => DeviceIconKind.Bar0,
+                    };
                 }
             }
             else if (isOnWindows11 && _device.Volume > 0.66f)

--- a/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
@@ -270,6 +270,6 @@ public class DeviceViewModel : AudioSessionViewModel, IDeviceViewModel
     }
 
     public void MakeDefaultDevice() => _deviceManager.Default = _device;
-    public void IncrementVolume(int delta) => Volume += delta;
+    public void IncrementVolume(float delta) => Volume += delta;
     public override string ToString() => AccessibleName;
 }

--- a/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
@@ -134,6 +134,25 @@ public class DeviceViewModel : AudioSessionViewModel, IDeviceViewModel
             {
                 IconKind = DeviceIconKind.Mute;
             }
+            else if (App.Settings.UseLogarithmicVolume)
+            {
+                if (_device.Volume > -6.2f)
+                {
+                    IconKind = DeviceIconKind.Bar3;
+                }
+                else if (_device.Volume > -16.6f)
+                {
+                    IconKind = DeviceIconKind.Bar2;
+                }
+                else if (_device.Volume > -96f)
+                {
+                    IconKind = DeviceIconKind.Bar1;
+                }
+                else
+                {
+                    IconKind = DeviceIconKind.Bar0;
+                }
+            }
             else if (isOnWindows11 && _device.Volume > 0.66f)
             {
                 IconKind = DeviceIconKind.Bar3;

--- a/EarTrumpet/UI/ViewModels/EarTrumpetCommunitySettingsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetCommunitySettingsPageViewModel.cs
@@ -6,7 +6,14 @@ public class EarTrumpetCommunitySettingsPageViewModel : SettingsPageViewModel
     public bool UseLogarithmicVolume
     {
         get => _settings.UseLogarithmicVolume;
-        set => _settings.UseLogarithmicVolume = value;
+        set
+        {
+            if (_settings.UseLogarithmicVolume != value)
+            {
+                _settings.UseLogarithmicVolume = value;
+                RaisePropertyChanged(nameof(UseLogarithmicVolume));
+            }
+        }
     }
 
     public double LogarithmicVolumeMinDb

--- a/EarTrumpet/UI/ViewModels/EarTrumpetCommunitySettingsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetCommunitySettingsPageViewModel.cs
@@ -9,15 +9,15 @@ public class EarTrumpetCommunitySettingsPageViewModel : SettingsPageViewModel
         set => _settings.UseLogarithmicVolume = value;
     }
 
-    public double LogarithmicVolumeMindB
+    public double LogarithmicVolumeMinDb
     {
-        get => _settings.LogarithmicVolumeMindB;
+        get => _settings.LogarithmicVolumeMinDb;
         set
         {
-            if (_settings.LogarithmicVolumeMindB != (float)value)
+            if (_settings.LogarithmicVolumeMinDb != (float)value)
             {
-                _settings.LogarithmicVolumeMindB = (float)value;
-                RaisePropertyChanged(nameof(LogarithmicVolumeMindB));
+                _settings.LogarithmicVolumeMinDb = (float)value;
+                RaisePropertyChanged(nameof(LogarithmicVolumeMinDb));
             }
         }
     }

--- a/EarTrumpet/UI/ViewModels/EarTrumpetCommunitySettingsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetCommunitySettingsPageViewModel.cs
@@ -9,6 +9,19 @@ public class EarTrumpetCommunitySettingsPageViewModel : SettingsPageViewModel
         set => _settings.UseLogarithmicVolume = value;
     }
 
+    public double LogarithmicVolumeMindB
+    {
+        get => _settings.LogarithmicVolumeMindB;
+        set
+        {
+            if (_settings.LogarithmicVolumeMindB != (float)value)
+            {
+                _settings.LogarithmicVolumeMindB = (float)value;
+                RaisePropertyChanged(nameof(LogarithmicVolumeMindB));
+            }
+        }
+    }
+
     public bool ShowFullMixerWindowOnStartup
     {
         get => _settings.ShowFullMixerWindowOnStartup;

--- a/EarTrumpet/UI/ViewModels/IAppItemViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/IAppItemViewModel.cs
@@ -9,7 +9,7 @@ public interface IAppItemViewModel : IAppIconSource, INotifyPropertyChanged
 {
     string Id { get; }
     bool IsMuted { get; set; }
-    int Volume { get; set; }
+    float Volume { get; set; }
     Color Background { get; }
     ObservableCollection<IAppItemViewModel> ChildApps { get; }
     string DisplayName { get; }

--- a/EarTrumpet/UI/ViewModels/SettingsAppItemViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/SettingsAppItemViewModel.cs
@@ -27,8 +27,8 @@ public class SettingsAppItemViewModel : BindableBase, IAppItemViewModel
         }
     }
 
-    private int _volume;
-    public int Volume
+    private float _volume;
+    public float Volume
     {
         get => _volume;
         set

--- a/EarTrumpet/UI/ViewModels/TemporaryAppItemViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/TemporaryAppItemViewModel.cs
@@ -34,7 +34,7 @@ public class TemporaryAppItemViewModel : BindableBase, IAppItemViewModel
             }
         }
     }
-    public int Volume
+    public float Volume
     {
         get => ChildApps != null ? ChildApps[0].Volume : _volume;
         set
@@ -71,7 +71,7 @@ public class TemporaryAppItemViewModel : BindableBase, IAppItemViewModel
     private readonly WeakReference<DeviceCollectionViewModel> _parent;
     private readonly Dispatcher _currentDispatcher = Dispatcher.CurrentDispatcher;
     private uint[] _processIds;
-    private int _volume;
+    private float _volume;
     private bool _isMuted;
 
     internal TemporaryAppItemViewModel(DeviceCollectionViewModel parent, IAudioDeviceManager deviceManager, IAppItemViewModel app, bool isChild = false)

--- a/EarTrumpet/UI/Views/AppItemView.xaml
+++ b/EarTrumpet/UI/Views/AppItemView.xaml
@@ -3,8 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:Theme="clr-namespace:EarTrumpet.UI.Themes"
              xmlns:ctl="clr-namespace:EarTrumpet.UI.Controls"
+             xmlns:conv="clr-namespace:EarTrumpet.UI.Converters"
              Height="{DynamicResource Mutable_AppItemCellHeight}"
              IsTabStop="False">
+    <UserControl.Resources>
+        <conv:VolumeToStringConverter x:Key="VolumeToStringConverter"/>
+    </UserControl.Resources>
     <Grid Name="GridRoot" Background="Transparent">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="{DynamicResource Mutable_IconCellWidth}" />
@@ -94,7 +98,7 @@
                 </Style>
             </ctl:VolumeSlider.Style>
         </ctl:VolumeSlider>
-        <TextBlock Grid.Column="2" Text="{Binding Volume, Mode=OneWay}">
+        <TextBlock Grid.Column="2" Text="{Binding Volume, Mode=OneWay, Converter={StaticResource VolumeToStringConverter}}">
             <TextBlock.Style>
                 <Style BasedOn="{StaticResource AppVolumeTextStyle}" TargetType="TextBlock">
                     <Style.Triggers>

--- a/EarTrumpet/UI/Views/DeviceView.xaml
+++ b/EarTrumpet/UI/Views/DeviceView.xaml
@@ -6,7 +6,11 @@
              xmlns:local="clr-namespace:EarTrumpet"
              xmlns:resx="clr-namespace:EarTrumpet.Properties"
              xmlns:views="clr-namespace:EarTrumpet.UI.Views"
+             xmlns:conv="clr-namespace:EarTrumpet.UI.Converters"
              IsTabStop="False">
+    <UserControl.Resources>
+        <conv:VolumeToStringConverter x:Key="VolumeToStringConverter"/>
+    </UserControl.Resources>
     <Grid Name="GridRoot">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -124,7 +128,7 @@
                                           Value="{Binding Device.Volume, Mode=TwoWay}" />
                         <TextBlock Grid.Column="2"
                                    Style="{StaticResource DeviceVolumeTextStyle}"
-                                   Text="{Binding Device.Volume, Mode=OneWay}" />
+                                   Text="{Binding Device.Volume, Mode=OneWay, Converter={StaticResource VolumeToStringConverter}}" />
                     </Grid>
                 </Grid>
             </Border>

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -194,10 +194,10 @@
                             IsSnapToTickEnabled="True"
                             TickFrequency="1"
                             IsDirectionReversed="True"
-                            Value="{Binding LogarithmicVolumeMindB, Mode=TwoWay}" />
+                            Value="{Binding LogarithmicVolumeMinDb, Mode=TwoWay}" />
                     <TextBlock VerticalAlignment="Center"
                                 Style="{StaticResource BodyText}"
-                                Text="{Binding LogarithmicVolumeMindB, StringFormat={}{0} dB}" />
+                                Text="{Binding LogarithmicVolumeMinDb, StringFormat={}{0} dB}" />
                 </StackPanel>
                 <CheckBox HorizontalAlignment="Left"
                           Content="{x:Static resx:Resources.SettingsShowFullMixerWindowOnStartup}"

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -183,7 +183,7 @@
                     <!-- Localization required -->
                     <TextBlock VerticalAlignment="Center"
                                Style="{StaticResource BodyText}"
-                               Text="Minimum dB in logarithmic slider" />
+                               Text="{x:Static resx:Resources.SettingsLogarithmicScaleMinimum}" />
                     <StackPanel Orientation="Horizontal"
                                 Margin="12,0,0,0"
                                 HorizontalAlignment="Left"

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -244,10 +244,25 @@
                                   HorizontalAlignment="Left"
                                   Content="{x:Static resx:Resources.PrivacyCheckboxText}"
                                   IsChecked="{Binding IsTelemetryEnabled, Mode=TwoWay}" />
-                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenPrivacyPolicyCommand}"><Run Text="{x:Static resx:Resources.PrivacyPolicyText}" /></Hyperlink></TextBlock>
-                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenAboutCommand}"><Run Text="{x:Static resx:Resources.WebsiteText}" /></Hyperlink></TextBlock>
-                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenFeedbackCommand}"><Run Text="{x:Static resx:Resources.ContextMenuSendFeedback}" /></Hyperlink></TextBlock>
-                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenDiagnosticsCommand}"><Run Text="{x:Static resx:Resources.TroubleshootEarTrumpetText}" /></Hyperlink></TextBlock>
+                        <TextBlock Style="{StaticResource HyperlinkBlock}">
+                            <Hyperlink Command="{Binding OpenPrivacyPolicyCommand}">
+                                <Run Text="{x:Static resx:Resources.PrivacyPolicyText}" />
+                            </Hyperlink>
+                        </TextBlock>
+                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenAboutCommand}">
+                                <Run Text="{x:Static resx:Resources.WebsiteText}" />
+                            </Hyperlink>
+                        </TextBlock>
+                        <TextBlock Style="{StaticResource HyperlinkBlock}">
+                            <Hyperlink Command="{Binding OpenFeedbackCommand}">
+                                <Run Text="{x:Static resx:Resources.ContextMenuSendFeedback}" />
+                            </Hyperlink>
+                        </TextBlock>
+                        <TextBlock Style="{StaticResource HyperlinkBlock}">
+                            <Hyperlink Command="{Binding OpenDiagnosticsCommand}">
+                                <Run Text="{x:Static resx:Resources.TroubleshootEarTrumpetText}" />
+                            </Hyperlink>
+                        </TextBlock>
                     </StackPanel>
                 </StackPanel>
             </StackPanel>
@@ -293,7 +308,9 @@
                                Style="{StaticResource BodySubText}"
                                Text="{Binding Version}" />
                 </Grid>
-                <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenHelpLink}"><Run Text="{x:Static resx:Resources.WebsiteText}" /></Hyperlink></TextBlock>
+                <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenHelpLink}">
+                        <Run Text="{x:Static resx:Resources.WebsiteText}" />
+                    </Hyperlink></TextBlock>
 
                 <TextBlock Style="{StaticResource HeadingText}" Text="{x:Static resx:Resources.AddonUninstallTitle}" />
                 <TextBlock Style="{StaticResource BodyText}" Text="{x:Static resx:Resources.AddonUninstallDescriptionText}" />
@@ -303,7 +320,7 @@
         <DataTemplate DataType="{x:Type vm:SettingsCategoryViewModel}">
             <Grid PreviewMouseRightButtonDown="{Event:HandledBinding}">
                 <Grid.Style>
-                    <Style TargetType="{x:Type Grid}">
+                    <Style TargetType="Grid">
                         <Setter Property="Background" Value="Transparent" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsAd}" Value="True">
@@ -317,7 +334,7 @@
                          Theme:Brush.Fill="SystemAccent"
                          Points="0,0 40,0 40,40">
                     <Polygon.Style>
-                        <Style TargetType="{x:Type Polygon}">
+                        <Style TargetType="Polygon">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsAd}" Value="False">
                                     <Setter Property="Visibility" Value="Collapsed" />
@@ -334,7 +351,7 @@
                            FontSize="12"
                            Text="&#xE896;">
                     <TextBlock.Style>
-                        <Style BasedOn="{StaticResource GlyphTextBlockStyle}" TargetType="{x:Type TextBlock}">
+                        <Style BasedOn="{StaticResource GlyphTextBlockStyle}" TargetType="TextBlock">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsAd}" Value="False">
                                     <Setter Property="Visibility" Value="Collapsed" />
@@ -360,7 +377,7 @@
                                FontSize="30"
                                Text="{Binding Glyph}">
                         <TextBlock.Style>
-                            <Style BasedOn="{StaticResource GlyphTextBlockStyle}" TargetType="{x:Type TextBlock}">
+                            <Style BasedOn="{StaticResource GlyphTextBlockStyle}" TargetType="TextBlock">
                                 <Setter Property="Theme:Brush.Foreground" Value="SystemAccent" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsAd}" Value="True">

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -179,7 +179,7 @@
                 <CheckBox HorizontalAlignment="Left"
                           Content="{x:Static resx:Resources.SettingsUseLogarithmicVolume}"
                           IsChecked="{Binding UseLogarithmicVolume, Mode=TwoWay}" />
-                <StackPanel Visibility="{Binding UseLogarithmicVolume, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <StackPanel>
                     <!-- Localization required -->
                     <TextBlock VerticalAlignment="Center"
                                Style="{StaticResource BodyText}"
@@ -196,6 +196,7 @@
                         <Slider Minimum="12"
                                 Maximum="96"
                                 Width="200"
+                                IsEnabled="{Binding UseLogarithmicVolume}"
                                 IsSnapToTickEnabled="True"
                                 TickFrequency="1"
                                 Value="{Binding LogarithmicVolumeMinDb, Converter={StaticResource NegateConverter}, Mode=TwoWay}" />

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -9,6 +9,7 @@
         xmlns:local="clr-namespace:EarTrumpet"
         xmlns:resx="clr-namespace:EarTrumpet.Properties"
         xmlns:vm="clr-namespace:EarTrumpet.UI.ViewModels"
+        xmlns:conv="clr-namespace:EarTrumpet.UI.Converters"
         Name="WindowRoot"
         Title="{Binding Title}"
         Width="800"
@@ -27,6 +28,8 @@
         UseLayoutRounding="True"
         WindowStartupLocation="CenterScreen">
     <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <conv:NegateConverter x:Key="NegateConverter"/>
         <DataTemplate DataType="{x:Type vm:EarTrumpetShortcutsPageViewModel}">
             <StackPanel Orientation="Vertical">
                 <TextBlock Style="{StaticResource BodyText}" Text="{x:Static resx:Resources.SettingsOpenEarTrumpetText}" />
@@ -176,28 +179,30 @@
                 <CheckBox HorizontalAlignment="Left"
                           Content="{x:Static resx:Resources.SettingsUseLogarithmicVolume}"
                           IsChecked="{Binding UseLogarithmicVolume, Mode=TwoWay}" />
-                <!-- Localization required -->
-                <TextBlock VerticalAlignment="Center"
-                            Style="{StaticResource BodyText}"
-                            Text="Minimum dB in logarithmic slider" />
-                <StackPanel Orientation="Horizontal"
-                            Margin="20,0,0,0"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Bottom">
+                <StackPanel Visibility="{Binding UseLogarithmicVolume, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <!-- Localization required -->
+                    <TextBlock VerticalAlignment="Center"
+                               Style="{StaticResource BodyText}"
+                               Text="Minimum dB in logarithmic slider" />
+                    <StackPanel Orientation="Horizontal"
+                                Margin="12,0,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Bottom">
                         <!--
                             -96 dB is the min volume range of most devices
                             -12 dB is arbitrarily chosen
+                            NegateConverter is used to flip the slider so that left is -12 and right is -96
                         -->
-                    <Slider Minimum="-96"
-                            Maximum="-12"
-                            Width="200"
-                            IsSnapToTickEnabled="True"
-                            TickFrequency="1"
-                            IsDirectionReversed="True"
-                            Value="{Binding LogarithmicVolumeMinDb, Mode=TwoWay}" />
-                    <TextBlock VerticalAlignment="Center"
-                                Style="{StaticResource BodyText}"
-                                Text="{Binding LogarithmicVolumeMinDb, StringFormat={}{0} dB}" />
+                        <Slider Minimum="12"
+                                Maximum="96"
+                                Width="200"
+                                IsSnapToTickEnabled="True"
+                                TickFrequency="1"
+                                Value="{Binding LogarithmicVolumeMinDb, Converter={StaticResource NegateConverter}, Mode=TwoWay}" />
+                        <TextBlock VerticalAlignment="Center"
+                                   Style="{StaticResource BodyText}"
+                                   Text="{Binding LogarithmicVolumeMinDb, StringFormat=\{0\} dB}" />
+                    </StackPanel>
                 </StackPanel>
                 <CheckBox HorizontalAlignment="Left"
                           Content="{x:Static resx:Resources.SettingsShowFullMixerWindowOnStartup}"
@@ -239,25 +244,10 @@
                                   HorizontalAlignment="Left"
                                   Content="{x:Static resx:Resources.PrivacyCheckboxText}"
                                   IsChecked="{Binding IsTelemetryEnabled, Mode=TwoWay}" />
-                        <TextBlock Style="{StaticResource HyperlinkBlock}">
-                            <Hyperlink Command="{Binding OpenPrivacyPolicyCommand}">
-                                <Run Text="{x:Static resx:Resources.PrivacyPolicyText}" />
-                            </Hyperlink>
-                        </TextBlock>
-                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenAboutCommand}">
-                                <Run Text="{x:Static resx:Resources.WebsiteText}" />
-                            </Hyperlink>
-                        </TextBlock>
-                        <TextBlock Style="{StaticResource HyperlinkBlock}">
-                            <Hyperlink Command="{Binding OpenFeedbackCommand}">
-                                <Run Text="{x:Static resx:Resources.ContextMenuSendFeedback}" />
-                            </Hyperlink>
-                        </TextBlock>
-                        <TextBlock Style="{StaticResource HyperlinkBlock}">
-                            <Hyperlink Command="{Binding OpenDiagnosticsCommand}">
-                                <Run Text="{x:Static resx:Resources.TroubleshootEarTrumpetText}" />
-                            </Hyperlink>
-                        </TextBlock>
+                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenPrivacyPolicyCommand}"><Run Text="{x:Static resx:Resources.PrivacyPolicyText}" /></Hyperlink></TextBlock>
+                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenAboutCommand}"><Run Text="{x:Static resx:Resources.WebsiteText}" /></Hyperlink></TextBlock>
+                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenFeedbackCommand}"><Run Text="{x:Static resx:Resources.ContextMenuSendFeedback}" /></Hyperlink></TextBlock>
+                        <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenDiagnosticsCommand}"><Run Text="{x:Static resx:Resources.TroubleshootEarTrumpetText}" /></Hyperlink></TextBlock>
                     </StackPanel>
                 </StackPanel>
             </StackPanel>
@@ -303,9 +293,7 @@
                                Style="{StaticResource BodySubText}"
                                Text="{Binding Version}" />
                 </Grid>
-                <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenHelpLink}">
-                        <Run Text="{x:Static resx:Resources.WebsiteText}" />
-                    </Hyperlink></TextBlock>
+                <TextBlock Style="{StaticResource HyperlinkBlock}"><Hyperlink Command="{Binding OpenHelpLink}"><Run Text="{x:Static resx:Resources.WebsiteText}" /></Hyperlink></TextBlock>
 
                 <TextBlock Style="{StaticResource HeadingText}" Text="{x:Static resx:Resources.AddonUninstallTitle}" />
                 <TextBlock Style="{StaticResource BodyText}" Text="{x:Static resx:Resources.AddonUninstallDescriptionText}" />
@@ -315,7 +303,7 @@
         <DataTemplate DataType="{x:Type vm:SettingsCategoryViewModel}">
             <Grid PreviewMouseRightButtonDown="{Event:HandledBinding}">
                 <Grid.Style>
-                    <Style TargetType="Grid">
+                    <Style TargetType="{x:Type Grid}">
                         <Setter Property="Background" Value="Transparent" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsAd}" Value="True">
@@ -329,7 +317,7 @@
                          Theme:Brush.Fill="SystemAccent"
                          Points="0,0 40,0 40,40">
                     <Polygon.Style>
-                        <Style TargetType="Polygon">
+                        <Style TargetType="{x:Type Polygon}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsAd}" Value="False">
                                     <Setter Property="Visibility" Value="Collapsed" />
@@ -346,7 +334,7 @@
                            FontSize="12"
                            Text="&#xE896;">
                     <TextBlock.Style>
-                        <Style BasedOn="{StaticResource GlyphTextBlockStyle}" TargetType="TextBlock">
+                        <Style BasedOn="{StaticResource GlyphTextBlockStyle}" TargetType="{x:Type TextBlock}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsAd}" Value="False">
                                     <Setter Property="Visibility" Value="Collapsed" />
@@ -372,7 +360,7 @@
                                FontSize="30"
                                Text="{Binding Glyph}">
                         <TextBlock.Style>
-                            <Style BasedOn="{StaticResource GlyphTextBlockStyle}" TargetType="TextBlock">
+                            <Style BasedOn="{StaticResource GlyphTextBlockStyle}" TargetType="{x:Type TextBlock}">
                                 <Setter Property="Theme:Brush.Foreground" Value="SystemAccent" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsAd}" Value="True">

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -176,7 +176,29 @@
                 <CheckBox HorizontalAlignment="Left"
                           Content="{x:Static resx:Resources.SettingsUseLogarithmicVolume}"
                           IsChecked="{Binding UseLogarithmicVolume, Mode=TwoWay}" />
-
+                <!-- Localization required -->
+                <TextBlock VerticalAlignment="Center"
+                            Style="{StaticResource BodyText}"
+                            Text="Minimum dB in logarithmic slider" />
+                <StackPanel Orientation="Horizontal"
+                            Margin="20,0,0,0"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Bottom">
+                        <!--
+                            -96 dB is the min volume range of most devices
+                            -12 dB is arbitrarily chosen
+                        -->
+                    <Slider Minimum="-96"
+                            Maximum="-12"
+                            Width="200"
+                            IsSnapToTickEnabled="True"
+                            TickFrequency="1"
+                            IsDirectionReversed="True"
+                            Value="{Binding LogarithmicVolumeMindB, Mode=TwoWay}" />
+                    <TextBlock VerticalAlignment="Center"
+                                Style="{StaticResource BodyText}"
+                                Text="{Binding LogarithmicVolumeMindB, StringFormat={}{0} dB}" />
+                </StackPanel>
                 <CheckBox HorizontalAlignment="Left"
                           Content="{x:Static resx:Resources.SettingsShowFullMixerWindowOnStartup}"
                           IsChecked="{Binding ShowFullMixerWindowOnStartup, Mode=TwoWay}" />


### PR DESCRIPTION
Related issue #1703 

All features mentioned in that issue are implemented.

# Added

- Logarithmic peak meter
- dB value on label instead of percent
- Adjustable logarithmic slider range (current default: 40 dB, range 12 to 96 dB)
  - This is meant to be calibrated by the user to their barely audible level
- Hot reload internal and UI state when certain settings are changed

# Changed

- Now uses logarithmic API for device volume, because SetMasterVolumeScalar is non-linear and we will get wrong result if we treat it as linear then compute log value based on it. Sessions are still work with linear API since they only have a linear API.
- Changed some view models' Volume field from int to float.

# Notes

- ~~Channels don't automatically get muted when slider is at the minimum, this is by design, not a bug, since it's still a non-zero value.~~

# Known Problems

- [x] Added UseLogarithmicVolumeChanged event handlers to various classes, but this may cause memory leak in AudioDeviceSession because that class don't have any clean up mechanism. (Finalizers won't work)
- [x] Slider value may occasionally flash to 0 (max) when dragging in logarithmic mode, actual volume is unaffected by this.
- [x] A TextBlock is yet to be localized.