### PR TITLE
Feature: Middle-click taskbar icon to toggle mute

### DIFF
--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -39,6 +39,7 @@ namespace EarTrumpet
         private WindowHolder _mixerWindow;
         private WindowHolder _settingsWindow;
         private ErrorReporter _errorReporter;
+        private TaskbarMiddleClickMuteService _taskbarMiddleClickMuteService;
 
         public static AppSettings Settings { get; private set; }
 
@@ -103,6 +104,9 @@ namespace EarTrumpet
 #endif
             _mixerWindow = new WindowHolder(CreateMixerExperience);
             _settingsWindow = new WindowHolder(CreateSettingsExperience);
+
+            _taskbarMiddleClickMuteService = new TaskbarMiddleClickMuteService(CollectionViewModel, Settings);
+            Exit += (_, __) => _taskbarMiddleClickMuteService?.Dispose();
 
             Settings.FlyoutHotkeyTyped += () => _flyoutViewModel.OpenFlyout(InputType.Keyboard);
             Settings.MixerHotkeyTyped += () => _mixerWindow.OpenOrClose();

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -145,6 +145,12 @@ namespace EarTrumpet
             set => _settings.Set("UseGlobalMouseWheelHook", value);
         }
 
+        public bool UseTaskbarMiddleClickMute
+        {
+            get => _settings.Get("UseTaskbarMiddleClickMute", false);
+            set => _settings.Set("UseTaskbarMiddleClickMute", value);
+        }
+
         public bool HasShownFirstRun
         {
             get => _settings.HasKey("hasShownFirstRun");

--- a/EarTrumpet/EarTrumpet.csproj
+++ b/EarTrumpet/EarTrumpet.csproj
@@ -64,12 +64,17 @@
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath Condition="Exists('$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll')">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
+    </Reference>
     <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath Condition="Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Windows.winmd</HintPath>
       <HintPath Condition="Exists('$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd')">$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
+    <Reference Include="UIAutomationClient" />
+    <Reference Include="UIAutomationTypes" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="XamlAnimatedGif, Version=2.0.0.0, Culture=neutral, PublicKeyToken=20a987d8023d9690, processorArchitecture=MSIL">
@@ -189,6 +194,7 @@
     <Compile Include="Extensions\EventBinding\HandledEventBindingExtension.cs" />
     <Compile Include="Extensions\FrameworkElementExtensions.cs" />
     <Compile Include="Extensions\ListExtensions.cs" />
+    <Compile Include="Extensions\TaskbarMiddleClickMuteService.cs" />
     <Compile Include="Features.cs" />
     <Compile Include="Interop\Helpers\AudioPolicyConfigFactoryImplFor21H2.cs" />
     <Compile Include="Interop\Helpers\AudioPolicyConfigFactoryImplForDownlevel.cs" />

--- a/EarTrumpet/Extensions/TaskbarMiddleClickMuteService.cs
+++ b/EarTrumpet/Extensions/TaskbarMiddleClickMuteService.cs
@@ -1,0 +1,213 @@
+using EarTrumpet.Interop.Helpers;
+using EarTrumpet.UI.ViewModels;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows.Automation;
+using System.Windows.Forms;
+
+namespace EarTrumpet.Extensions
+{
+    public class TaskbarMiddleClickMuteService : IDisposable
+    {
+        private readonly MouseHook _mouseHook;
+        private readonly DeviceCollectionViewModel _collectionViewModel;
+        private readonly AppSettings _settings;
+        private bool _disposed = false;
+
+        public TaskbarMiddleClickMuteService(DeviceCollectionViewModel collectionViewModel, AppSettings settings)
+        {
+            _collectionViewModel = collectionViewModel;
+            _settings = settings;
+            _mouseHook = new MouseHook();
+            _mouseHook.MiddleClickEvent += OnMiddleClick;
+            _mouseHook.SetHook();
+        }
+
+        private int OnMiddleClick(object sender, MouseEventArgs e)
+        {
+            if (!_settings.UseTaskbarMiddleClickMute)
+            {
+                return 0; 
+            }
+
+            try
+            {
+                if (!IsClickOnTaskbar(e.X, e.Y))
+                {
+                    return 0;
+                }
+
+                System.Threading.Tasks.Task.Run(() => 
+                {
+                    try
+                    {
+                        string appName = GetTaskbarButtonAppName(e.X, e.Y);
+                        if (!string.IsNullOrEmpty(appName))
+                        {
+                            ToggleMuteForApp(appName);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.WriteLine($"TaskbarMiddleClickMuteService error: {ex.Message}");
+                    }
+                });
+
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"TaskbarMiddleClickMuteService OnMiddleClick error: {ex.Message}");
+            }
+
+            return 0;
+        }
+
+        private bool IsClickOnTaskbar(int x, int y)
+        {
+            try
+            {
+                var taskbarState = WindowsTaskbar.Current;
+                var point = new System.Drawing.Point(x, y);
+                
+                var rect = taskbarState.Size;
+                var bounds = new System.Drawing.Rectangle(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top);
+                
+                if (bounds.Contains(point))
+                {
+                    return true;
+                }
+            }
+            catch { }
+            return false;
+        }
+
+        private string GetTaskbarButtonAppName(int x, int y)
+        {
+            try
+            {
+                var point = new System.Windows.Point(x, y);
+                AutomationElement element = AutomationElement.FromPoint(point);
+
+                if (element == null)
+                    return null;
+
+                AutomationElement current = element;
+                int maxDepth = 10;
+                int depth = 0;
+
+                while (current != null && depth < maxDepth)
+                {
+                    string name = current.Current.Name;
+                    string className = current.Current.ClassName;
+                    var controlType = current.Current.ControlType;
+
+                    if (!string.IsNullOrEmpty(name) && 
+                        (className == "Taskbar.TaskListButtonAutomationPeer" ||
+                         className.Contains("TaskListButton") ||
+                         controlType == ControlType.Button ||
+                         controlType == ControlType.ListItem ||
+                         controlType == ControlType.MenuItem)) 
+                    {
+                        string cleanName = CleanAppName(name);
+                        if (!string.IsNullOrEmpty(cleanName))
+                        {
+                            return cleanName;
+                        }
+                    }
+
+                    try
+                    {
+                        TreeWalker walker = TreeWalker.ControlViewWalker;
+                        current = walker.GetParent(current);
+                        depth++;
+                    }
+                    catch
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"TaskbarMiddleClickMuteService GetTaskbarButtonAppName error: {ex.Message}");
+            }
+
+            return null;
+        }
+
+        private string CleanAppName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return null;
+
+            string cleanName = name;
+
+            cleanName = System.Text.RegularExpressions.Regex.Replace(cleanName, @"\s*-\s*\d+\s*.*$", "");
+
+            int dashIndex = cleanName.IndexOf(" - ");
+            if (dashIndex > 0)
+            {
+                cleanName = cleanName.Substring(0, dashIndex);
+            }
+
+            cleanName = System.Text.RegularExpressions.Regex.Replace(cleanName, @"\s*\(\d+\)\s*$", "");
+            
+            return cleanName.Trim();
+        }
+
+        private bool ToggleMuteForApp(string appName)
+        {
+            if (string.IsNullOrEmpty(appName))
+                return false;
+
+            string lowerAppName = appName.ToLowerInvariant();
+
+            foreach (var device in _collectionViewModel.AllDevices)
+            {
+                foreach (var app in device.Apps)
+                {
+                    string displayName = app.DisplayName?.ToLowerInvariant() ?? "";
+                    string exeName = app.ExeName?.ToLowerInvariant() ?? "";
+
+                    if (displayName.Contains(lowerAppName) || 
+                        lowerAppName.Contains(displayName) ||
+                        exeName.Contains(lowerAppName) ||
+                        lowerAppName.Contains(exeName.Replace(".exe", "")))
+                    {
+                        app.IsMuted = !app.IsMuted;
+                        Trace.WriteLine($"TaskbarMiddleClickMuteService toggled mute for {app.DisplayName}");
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _mouseHook.MiddleClickEvent -= OnMiddleClick;
+                    _mouseHook.UnHook();
+                }
+                _disposed = true;
+            }
+        }
+
+        ~TaskbarMiddleClickMuteService()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/EarTrumpet/Properties/Resources.Designer.cs
+++ b/EarTrumpet/Properties/Resources.Designer.cs
@@ -648,6 +648,15 @@ namespace EarTrumpet.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Middle-click on a taskbar app icon to toggle mute.
+        /// </summary>
+        public static string SettingsUseTaskbarMiddleClickMute {
+            get {
+                return ResourceManager.GetString("SettingsUseTaskbarMiddleClickMute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to  EarTrumpet {Option}.
         /// </summary>
         public static string EventTrigger_LinkText {

--- a/EarTrumpet/Properties/Resources.resx
+++ b/EarTrumpet/Properties/Resources.resx
@@ -665,4 +665,7 @@ Open [https://eartrumpet.app/jmp/fixfonts] now?</value>
   <data name="SettingsUseLogarithmicVolume" xml:space="preserve">
     <value>Use logarithmic volume scale</value>
   </data>
+  <data name="SettingsUseTaskbarMiddleClickMute" xml:space="preserve">
+    <value>Middle-click on a taskbar app icon to toggle mute</value>
+  </data>
 </root>

--- a/EarTrumpet/UI/ViewModels/EarTrumpetMouseSettingsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetMouseSettingsPageViewModel.cs
@@ -16,6 +16,12 @@ namespace EarTrumpet.UI.ViewModels
             set => _settings.UseGlobalMouseWheelHook = value;
         }
 
+        public bool UseTaskbarMiddleClickMute
+        {
+            get => _settings.UseTaskbarMiddleClickMute;
+            set => _settings.UseTaskbarMiddleClickMute = value;
+        }
+
         private readonly AppSettings _settings;
 
         public EarTrumpetMouseSettingsPageViewModel(AppSettings settings) : base(null)

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -169,6 +169,9 @@
                 <CheckBox HorizontalAlignment="Left"
                           Content="{x:Static resx:Resources.SettingsUseGlobalMouseWheelHook}"
                           IsChecked="{Binding UseGlobalMouseWheelHook, Mode=TwoWay}" />
+                <CheckBox HorizontalAlignment="Left"
+                          Content="{x:Static resx:Resources.SettingsUseTaskbarMiddleClickMute}"
+                          IsChecked="{Binding UseTaskbarMiddleClickMute, Mode=TwoWay}" />
             </StackPanel>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:EarTrumpetCommunitySettingsPageViewModel}">


### PR DESCRIPTION
- Middle-click any running app icon on the taskbar to mute/unmute it.
- Added a new checkbox "Middle-click on a taskbar app icon to toggle mute" in Mouse settings (disabled by default).
- Uses a low-level mouse hook (WM_MBUTTONDOWN) to capture clicks.
- Identifies target apps using UI Automation asynchronously.
- Suppresses the default "open new instance" behavior when the action is handled.
<img width="832" height="512" alt="image" src="https://github.com/user-attachments/assets/50b91b58-510b-4afc-af9a-ff97183b0363" />
