### PR TITLE
Add focused app volume hotkeys

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,3 +45,7 @@ jobs:
           /p:Platform=arm64
           /p:DisableGitVersionTask=true
           EarTrumpet\EarTrumpet.csproj
+
+      - name: Test focused app controls
+        shell: cmd
+        run: dotnet run --project EarTrumpet.Tests\EarTrumpet.Tests.csproj -c Release -p:Platform=x64 -p:DisableGitVersionTask=true

--- a/EarTrumpet.Tests/AudioDeviceSessionVolumeTests.cs
+++ b/EarTrumpet.Tests/AudioDeviceSessionVolumeTests.cs
@@ -1,0 +1,101 @@
+using EarTrumpet.DataModel.Storage;
+using EarTrumpet.DataModel.WindowsAudio.Internal;
+using EarTrumpet.UI.Helpers;
+using EarTrumpet.UI.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Windows.Win32.Foundation;
+using Windows.Win32.Media.Audio;
+
+namespace EarTrumpet.Tests;
+
+internal static class AudioDeviceSessionVolumeTests
+{
+    internal static IEnumerable<(string Name, Action Test)> Cases()
+    {
+        yield return ("Repeated logarithmic shortcuts work before audio callbacks arrive", RepeatedLogarithmicSteps);
+        yield return ("Logarithmic writes preserve scalar readback at boundaries", ScalarReadback);
+    }
+
+    private static void RepeatedLogarithmicSteps()
+    {
+        using var fixture = new SessionFixture();
+        fixture.Session.SetVolumeScalar(0.1f);
+        var app = new AppItemViewModel(null, fixture.Session);
+
+        for (var step = 1; step <= 3; step++)
+        {
+            FocusedAppAudioControl.ChangeVolume(new[] { app }, -0.5f, -40, 0);
+            Near(-20f - step * 0.5f, app.Volume);
+            Near(fixture.Endpoint.Scalar, fixture.Session.GetVolumeScalar());
+        }
+    }
+
+    private static void ScalarReadback()
+    {
+        using var fixture = new SessionFixture();
+        foreach (var (requested, expectedDb, expectedScalar) in new[]
+        {
+            (-20f, -20f, 0.1f), (-50f, -40f, 0.01f), (10f, 0f, 1f),
+        })
+        {
+            fixture.Session.SetVolumeLogarithmic(requested);
+            Near(expectedDb, fixture.Session.GetVolumeLogarithmic());
+            Near(expectedScalar, fixture.Session.GetVolumeScalar());
+            Near(expectedScalar, fixture.Endpoint.Scalar);
+        }
+    }
+
+    private static void Near(float expected, float actual)
+    {
+        if (!float.IsFinite(actual) || Math.Abs(expected - actual) > 0.0001f)
+        {
+            throw new InvalidOperationException($"Expected approximately {expected}, got {actual}.");
+        }
+    }
+
+    private sealed class SessionFixture : IDisposable
+    {
+        private readonly AppSettings _previousSettings = App.Settings;
+        public AudioDeviceSession Session { get; }
+        public SimpleVolume Endpoint { get; } = new();
+
+        public SessionFixture()
+        {
+            // Exercise the real view model and session setters without a COM connection,
+            // audio callbacks, or access to the user's saved settings.
+            var settings = new AppSettings();
+            typeof(AppSettings).GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(settings, new LogarithmicSettings());
+            typeof(App).GetProperty(nameof(App.Settings)).SetValue(null, settings);
+            Session = (AudioDeviceSession)RuntimeHelpers.GetUninitializedObject(typeof(AudioDeviceSession));
+            GC.SuppressFinalize(Session);
+            typeof(AudioDeviceSession).GetField("_simpleVolume", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(Session, Endpoint);
+        }
+
+        public void Dispose() => typeof(App).GetProperty(nameof(App.Settings)).SetValue(null, _previousSettings);
+    }
+
+    private sealed class LogarithmicSettings : ISettingsBag
+    {
+        public string Namespace => "";
+        public bool HasKey(string key) => key == nameof(AppSettings.UseLogarithmicVolume);
+        public T Get<T>(string key, T defaultValue) => key == nameof(AppSettings.UseLogarithmicVolume)
+            ? (T)(object)true : defaultValue;
+        public void Set<T>(string key, T value) => throw new NotSupportedException();
+        public event EventHandler<string> SettingChanged { add { } remove { } }
+    }
+
+    private sealed unsafe class SimpleVolume : ISimpleAudioVolume
+    {
+        public float Scalar { get; private set; }
+        private BOOL _muted;
+        public void SetMasterVolume(float value, Guid* context) => Scalar = value;
+        public void GetMasterVolume(out float value) => value = Scalar;
+        public void SetMute(BOOL value, Guid* context) => _muted = value;
+        public void GetMute(BOOL* value) => *value = _muted;
+    }
+}

--- a/EarTrumpet.Tests/EarTrumpet.Tests.csproj
+++ b/EarTrumpet.Tests/EarTrumpet.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Platform>x64</Platform>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EarTrumpet\EarTrumpet.csproj" />
+  </ItemGroup>
+</Project>

--- a/EarTrumpet.Tests/FocusedAppAudioControlTests.cs
+++ b/EarTrumpet.Tests/FocusedAppAudioControlTests.cs
@@ -1,0 +1,190 @@
+using EarTrumpet.UI.Helpers;
+using EarTrumpet.UI.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Media;
+
+namespace EarTrumpet.Tests;
+
+internal static class FocusedAppAudioControlTests
+{
+    internal static IEnumerable<(string Name, Action Test)> Cases()
+    {
+        yield return ("Volume steps preserve levels across nested groups and devices", PreservesLevels);
+        yield return ("Logarithmic steps preserve each stream's level", PreservesLogarithmicLevels);
+        yield return ("Volume steps clamp each stream independently", ClampsVolume);
+        yield return ("Non-finite volumes recover at the current mode's minimum", RecoversNonFiniteVolume);
+        yield return ("Mixed mute states mute every stream regardless of child order", MutesMixedStreams);
+        yield return ("All-muted streams unmute across devices", UnmutesAllStreams);
+        yield return ("Leaf placeholders retain volume and mute changes", UpdatesPlaceholders);
+        yield return ("Empty targets are harmless", HandlesEmptyTargets);
+        yield return ("Volume changes use a snapshot of target streams", SnapshotsTargets);
+    }
+
+    private static void PreservesLevels()
+    {
+        var first = new TestApp(50);
+        var second = new TestApp(10);
+        var otherDevice = new TestApp(70);
+        var targets = new[] { Group(Group(first, second)), Group(Group(otherDevice)) };
+
+        FocusedAppAudioControl.ChangeVolume(targets, -2, 0, 100);
+        Check.SequenceEqual(new[] { 48f, 8f, 68f }, new[] { first.Volume, second.Volume, otherDevice.Volume });
+
+        FocusedAppAudioControl.ChangeVolume(targets, 2, 0, 100);
+        Check.SequenceEqual(new[] { 50f, 10f, 70f }, new[] { first.Volume, second.Volume, otherDevice.Volume });
+    }
+
+    private static void PreservesLogarithmicLevels()
+    {
+        var first = new TestApp(-5);
+        var second = new TestApp(-20);
+        var targets = new[] { Group(Group(first, second)) };
+        FocusedAppAudioControl.ChangeVolume(targets, -0.5f, -40, 0);
+        FocusedAppAudioControl.ChangeVolume(targets, -0.5f, -40, 0);
+        Check.Equal(-6f, first.Volume);
+        Check.Equal(-21f, second.Volume);
+    }
+
+    private static void ClampsVolume()
+    {
+        foreach (var (volume, delta, minimum, maximum, expected) in new[]
+        {
+            (1f, -2f, 0f, 100f, 0f),
+            (99f, 2f, 0f, 100f, 100f),
+            (0f, -2f, 0f, 100f, 0f),
+            (100f, 2f, 0f, 100f, 100f),
+            (-39.75f, -0.5f, -40f, 0f, -40f),
+            (-0.25f, 0.5f, -40f, 0f, 0f),
+            (-60f, -0.5f, -60f, 0f, -60f),
+        })
+        {
+            var app = new TestApp(volume);
+            FocusedAppAudioControl.ChangeVolume(new[] { Group(Group(app)) }, delta, minimum, maximum);
+            Check.Equal(expected, app.Volume);
+        }
+    }
+
+    private static void RecoversNonFiniteVolume()
+    {
+        foreach (var invalid in new[] { float.NaN, float.NegativeInfinity, float.PositiveInfinity })
+        {
+            foreach (var (minimum, maximum, delta) in new[] { (0f, 100f, 2f), (-40f, 0f, 0.5f) })
+            {
+                var app = new TestApp(invalid);
+                FocusedAppAudioControl.ChangeVolume(new[] { app }, delta, minimum, maximum);
+                Check.Equal(minimum + delta, app.Volume);
+            }
+        }
+    }
+
+    private static void MutesMixedStreams()
+    {
+        foreach (var firstMuted in new[] { true, false })
+        {
+            var first = new TestApp(50) { IsMuted = firstMuted };
+            var second = new TestApp(10) { IsMuted = !firstMuted };
+            var otherDevice = new TestApp(70) { IsMuted = true };
+            FocusedAppAudioControl.ToggleMute(new[] { Group(Group(first, second)), Group(otherDevice) });
+            Check.True(first.IsMuted && second.IsMuted && otherDevice.IsMuted);
+        }
+    }
+
+    private static void UnmutesAllStreams()
+    {
+        var first = new TestApp(50) { IsMuted = true };
+        var second = new TestApp(10) { IsMuted = true };
+        FocusedAppAudioControl.ToggleMute(new[] { Group(Group(first)), Group(Group(second)) });
+        Check.True(!first.IsMuted && !second.IsMuted);
+    }
+
+    private static void UpdatesPlaceholders()
+    {
+        var first = new TestApp(50) { ChildApps = new ObservableCollection<IAppItemViewModel>() };
+        var second = new TestApp(10);
+        var placeholder = Group(Group(first, second));
+        FocusedAppAudioControl.ChangeVolume(new[] { placeholder }, -2, 0, 100);
+        FocusedAppAudioControl.ToggleMute(new[] { placeholder });
+        Check.Equal(48f, first.Volume);
+        Check.Equal(8f, second.Volume);
+        Check.True(first.IsMuted && second.IsMuted);
+    }
+
+    private static void HandlesEmptyTargets()
+    {
+        FocusedAppAudioControl.ChangeVolume(Array.Empty<IAppItemViewModel>(), 2, 0, 100);
+        FocusedAppAudioControl.ToggleMute(Array.Empty<IAppItemViewModel>());
+    }
+
+    private static void SnapshotsTargets()
+    {
+        var first = new TestApp(50);
+        var second = new TestApp(10);
+        var group = Group(first, second);
+        first.VolumeChanged = () => group.ChildApps.Remove(second);
+        FocusedAppAudioControl.ChangeVolume(new[] { group }, -2, 0, 100);
+        Check.Equal(48f, first.Volume);
+        Check.Equal(8f, second.Volume);
+    }
+
+    private static TestApp Group(params IAppItemViewModel[] children) => new(0)
+    {
+        ChildApps = new ObservableCollection<IAppItemViewModel>(children),
+    };
+
+    // Match mixer group semantics: reads use the first child, writes affect all children.
+    private sealed class TestApp(float volume) : BindableBase, IAppItemViewModel
+    {
+        private float _volume = volume;
+        private bool _muted;
+        public Action VolumeChanged { get; set; }
+        public ObservableCollection<IAppItemViewModel> ChildApps { get; set; }
+        public float Volume
+        {
+            get => ChildApps?.Count > 0 ? ChildApps[0].Volume : _volume;
+            set
+            {
+                if (ChildApps?.Count > 0)
+                {
+                    foreach (var child in ChildApps) child.Volume = value;
+                }
+                else _volume = value;
+                VolumeChanged?.Invoke();
+            }
+        }
+        public bool IsMuted
+        {
+            get => ChildApps?.Count > 0 ? ChildApps[0].IsMuted : _muted;
+            set
+            {
+                if (ChildApps?.Count > 0)
+                {
+                    foreach (var child in ChildApps) child.IsMuted = value;
+                }
+                else _muted = value;
+            }
+        }
+        public string Id => "session";
+        public string AppId => "app";
+        public string DisplayName => "Test app";
+        public string ExeName => AppId;
+        public string PackageInstallPath => null;
+        public string IconPath => null;
+        public Color Background => default;
+        public char IconText => 'T';
+        public bool IsDesktopApp => true;
+        public bool IsExpanded => false;
+        public bool IsMovable => false;
+        public float PeakValue1 => 0;
+        public float PeakValue2 => 0;
+        public string PersistedOutputDevice => null;
+        public uint ProcessId => 0;
+        public IDeviceViewModel Parent => null;
+        public bool DoesGroupWith(IAppItemViewModel app) => AppId == app.AppId;
+        public void MoveToDevice(string id, bool hide) => throw new NotSupportedException();
+        public void UpdatePeakValueForeground() { }
+        public void UpdatePeakValueBackground() { }
+    }
+}

--- a/EarTrumpet.Tests/ForegroundAppResolverTests.cs
+++ b/EarTrumpet.Tests/ForegroundAppResolverTests.cs
@@ -1,0 +1,156 @@
+using EarTrumpet.DataModel.Audio;
+using EarTrumpet.DataModel.WindowsAudio;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using static EarTrumpet.DataModel.Audio.ForegroundAppResolver;
+
+namespace EarTrumpet.Tests;
+
+internal static class ForegroundAppResolverTests
+{
+    public static IEnumerable<(string Name, Action Test)> Cases()
+    {
+        yield return ("Resolver uses nested leaf activity and IDs in either order", NestedLeaves);
+        yield return ("Resolver never borrows active state from a sibling", InactiveDescendant);
+        yield return ("Resolver retains all distinct active apps for ambiguity fallback", DistinctActiveApps);
+        yield return ("Resolver handles empty and missing inputs", EmptyInputs);
+        yield return ("Resolver requires intact strict ancestry and terminates cycles", StrictAncestry);
+        yield return ("Resolver rejects reused direct and intermediate parent IDs", ReusedParentIds);
+    }
+
+    private static void NestedLeaves()
+    {
+        var processes = Snapshot((1, 0, 10), (2, 1, 20), (3, 0, 30));
+        var active = new Session(2, "leaf-active", SessionState.Active);
+        var inactive = new Session(3, "leaf-inactive", SessionState.Inactive);
+        foreach (var leaves in new[] { new[] { inactive, active }, new[] { active, inactive } })
+        {
+            var inner = new Session(leaves[0].ProcessId, "grouping-parameter", SessionState.Active, leaves);
+            var root = new Session(inner.ProcessId, "root-app", SessionState.Active, inner);
+            var candidates = EnumerateSessionCandidates(new[] { root }).ToArray();
+
+            Check.SequenceEqual(leaves.Select(leaf => (leaf.ProcessId, "root-app", leaf.State)),
+                candidates.Select(candidate => (candidate.ProcessId, candidate.AppId, candidate.State)));
+            Check.SequenceEqual(new[] { "root-app" }, GetActiveDescendantAppIds(1, processes, candidates));
+        }
+    }
+
+    private static void InactiveDescendant()
+    {
+        var processes = Snapshot((1, 0, 10), (2, 1, 20), (3, 0, 30));
+        var inner = new Session(2, "grouping-parameter", SessionState.Active,
+            new Session(2, "inactive-descendant", SessionState.Inactive),
+            new Session(3, "active-unrelated", SessionState.Active));
+        var root = new Session(2, "root-app", SessionState.Active, inner);
+
+        Check.Equal(0, GetActiveDescendantAppIds(1, processes,
+            EnumerateSessionCandidates(new[] { root })).Count);
+    }
+
+    private static void DistinctActiveApps()
+    {
+        var processes = Snapshot((1, 0, 10), (2, 1, 20), (3, 2, 30));
+        var candidates = new[]
+        {
+            new SessionCandidate(2, "z-app", SessionState.Active),
+            new SessionCandidate(3, "a-app", SessionState.Active),
+            new SessionCandidate(3, "z-app", SessionState.Active),
+            new SessionCandidate(2, "expired", SessionState.Expired),
+            new SessionCandidate(2, "moved", SessionState.Moved),
+            new SessionCandidate(2, "inactive", SessionState.Inactive),
+            new SessionCandidate(2, " ", SessionState.Active),
+            new SessionCandidate(2, null, SessionState.Active),
+            new SessionCandidate(1, "foreground", SessionState.Active),
+        };
+
+        Check.SequenceEqual(new[] { "a-app", "z-app" }, GetActiveDescendantAppIds(1, processes, candidates));
+        Check.SequenceEqual(new[] { "a-app", "z-app" }, GetActiveDescendantAppIds(1, processes, candidates.Reverse()));
+    }
+
+    private static void EmptyInputs()
+    {
+        var processes = Snapshot((1, 0, 10), (2, 1, 20));
+        var candidates = new[] { new SessionCandidate(2, "app", SessionState.Active) };
+        Check.Equal(0, EnumerateSessionCandidates(null).Count());
+        Check.Equal(0, EnumerateSessionCandidates(Array.Empty<IAudioDeviceSession>()).Count());
+        Check.Equal(0, EnumerateSessionCandidates(new IAudioDeviceSession[] { null }).Count());
+        Check.Equal(0, GetActiveDescendantAppIds(0, processes, candidates).Count);
+        Check.Equal(0, GetActiveDescendantAppIds(1, null, candidates).Count);
+        Check.Equal(0, GetActiveDescendantAppIds(1, processes, null).Count);
+        Check.Equal(0, GetActiveDescendantAppIds(1, processes, Array.Empty<SessionCandidate>()).Count);
+        Check.Equal(0, GetActiveDescendantAppIds(1, Snapshot(), candidates).Count);
+
+        var leaf = new Session(2, "app", SessionState.Active);
+        Check.SequenceEqual(new[] { "app" }, GetActiveDescendantAppIds(1, processes,
+            EnumerateSessionCandidates(new[] { leaf })));
+    }
+
+    private static void StrictAncestry()
+    {
+        var processes = Snapshot((1, 0, 10), (2, 1, 20), (3, 2, 30),
+            (4, 99, 40), (5, 6, 50), (6, 5, 50), (7, 7, 70), (8, 0, 80));
+        foreach (var processId in new uint[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 99 })
+        {
+            var candidates = new[] { new SessionCandidate(processId, "app", SessionState.Active) };
+            Check.Equal(processId == 2 || processId == 3 ? 1 : 0,
+                GetActiveDescendantAppIds(1, processes, candidates).Count);
+        }
+
+        // Even a direct parent ID must resolve to a live entry in this snapshot.
+        Check.Equal(0, GetActiveDescendantAppIds(1, Snapshot((2, 1, 20)),
+            new[] { new SessionCandidate(2, "app", SessionState.Active) }).Count);
+    }
+
+    private static void ReusedParentIds()
+    {
+        var direct = new[] { new SessionCandidate(2, "app", SessionState.Active) };
+        var descendant = new[] { new SessionCandidate(3, "app", SessionState.Active) };
+        Check.Equal(0, GetActiveDescendantAppIds(1, Snapshot((1, 0, 30), (2, 1, 20)), direct).Count);
+        Check.Equal(0, GetActiveDescendantAppIds(1,
+            Snapshot((1, 0, 10), (2, 1, 40), (3, 2, 30)), descendant).Count);
+        Check.Equal(0, GetActiveDescendantAppIds(1,
+            Snapshot((1, 0, 40), (2, 1, 20), (3, 2, 30)), descendant).Count);
+        Check.SequenceEqual(new[] { "app" }, GetActiveDescendantAppIds(1,
+            Snapshot((1, 0, 10), (2, 1, 10), (3, 2, 20)), descendant));
+    }
+
+    private static IReadOnlyDictionary<uint, ProcessSnapshotEntry> Snapshot(params (uint Id, uint ParentId, long Time)[] entries)
+        => entries.ToDictionary(entry => entry.Id, entry => new ProcessSnapshotEntry(entry.ParentId, entry.Time));
+
+    private sealed class Session : IAudioDeviceSession
+    {
+        public Session(uint processId, string appId, SessionState state, params Session[] children)
+        {
+            ProcessId = processId;
+            AppId = appId;
+            State = state;
+            Children = new ObservableCollection<IAudioDeviceSession>(children);
+        }
+
+        public uint ProcessId { get; }
+        public string AppId { get; }
+        public SessionState State { get; }
+        public ObservableCollection<IAudioDeviceSession> Children { get; }
+        public event PropertyChangedEventHandler PropertyChanged { add { } remove { } }
+        public IEnumerable<IAudioDeviceSessionChannel> Channels => throw new NotSupportedException();
+        public IAudioDevice Parent => throw new NotSupportedException();
+        public string DisplayName => throw new NotSupportedException();
+        public string ExeName => throw new NotSupportedException();
+        public string IconPath => throw new NotSupportedException();
+        public bool IsDesktopApp => throw new NotSupportedException();
+        public bool IsSystemSoundsSession => throw new NotSupportedException();
+        public string PackageInstallPath => throw new NotSupportedException();
+        public string Id => throw new NotSupportedException();
+        public bool IsMuted { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public float Volume { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public float PeakValue1 => throw new NotSupportedException();
+        public float PeakValue2 => throw new NotSupportedException();
+        public float GetVolumeScalar() => throw new NotSupportedException();
+        public float GetVolumeLogarithmic() => throw new NotSupportedException();
+        public void SetVolumeScalar(float value) => throw new NotSupportedException();
+        public void SetVolumeLogarithmic(float value) => throw new NotSupportedException();
+    }
+}

--- a/EarTrumpet.Tests/Program.cs
+++ b/EarTrumpet.Tests/Program.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EarTrumpet.Tests;
+
+internal static class Program
+{
+    [STAThread]
+    private static int Main()
+    {
+        var failures = 0;
+        var cases = FocusedAppAudioControlTests.Cases()
+            .Concat(ForegroundAppResolverTests.Cases())
+            .Concat(AudioDeviceSessionVolumeTests.Cases()).ToArray();
+        foreach (var (name, test) in cases)
+        {
+            try
+            {
+                test();
+                Console.WriteLine($"PASS {name}");
+            }
+            catch (Exception ex)
+            {
+                failures++;
+                Console.Error.WriteLine($"FAIL {name}: {ex}");
+            }
+        }
+
+        Console.WriteLine($"{cases.Length - failures}/{cases.Length} tests passed.");
+        return failures == 0 ? 0 : 1;
+    }
+}
+
+internal static class Check
+{
+    internal static void True(bool condition)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException("Expected true.");
+        }
+    }
+
+    internal static void Equal<T>(T expected, T actual)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException($"Expected {expected}, got {actual}.");
+        }
+    }
+
+    internal static void SequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+    {
+        if (!expected.SequenceEqual(actual))
+        {
+            throw new InvalidOperationException($"Expected [{string.Join(", ", expected)}], got [{string.Join(", ", actual)}].");
+        }
+    }
+}

--- a/EarTrumpet.Tests/README.md
+++ b/EarTrumpet.Tests/README.md
@@ -1,0 +1,11 @@
+# Focused app regression tests
+
+Run on Windows with the repository's .NET SDK:
+
+```powershell
+dotnet run --project EarTrumpet.Tests/EarTrumpet.Tests.csproj -c Release -p:Platform=x64
+```
+
+This dependency-free runner exercises the production assembly with in-memory audio streams and process snapshots. A failure returns a nonzero exit code. It does not register shortcuts, change audio devices, or start the EarTrumpet application.
+
+The project reference uses EarTrumpet's normal build, which updates the package manifest version. That generated version change should not be committed with source changes.

--- a/EarTrumpet/Addons/EarTrumpet.Actions/DataModel/Processing/ActionProcessor.cs
+++ b/EarTrumpet/Addons/EarTrumpet.Actions/DataModel/Processing/ActionProcessor.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using EarTrumpet.Actions.DataModel.Enum;
 using EarTrumpet.Actions.DataModel.Serialization;
-using EarTrumpet.DataModel.AppInformation;
 using EarTrumpet.DataModel.Audio;
 using EarTrumpet.DataModel.WindowsAudio;
 using EarTrumpet.Extensions;
-using Windows.Win32;
 
 namespace EarTrumpet.Actions.DataModel.Processing;
 
@@ -41,7 +38,7 @@ internal class ActionProcessor
             {
                 if (setAppVolumeAction.App.Id == AppRef.ForegroundAppId)
                 {
-                    var app = FindForegroundApp(device.Groups);
+                    var app = ForegroundAppResolver.FindForegroundApp(device.Groups);
                     if (app != null)
                     {
                         DoAudioAction(setAppVolumeAction.Option, app, setAppVolumeAction);
@@ -66,7 +63,7 @@ internal class ActionProcessor
             {
                 if (setAppMuteAction.App.Id == AppRef.ForegroundAppId)
                 {
-                    var app = FindForegroundApp(device.Groups);
+                    var app = ForegroundAppResolver.FindForegroundApp(device.Groups);
                     if (app != null)
                     {
                         DoAudioAction(setAppMuteAction.Option, app);
@@ -107,64 +104,6 @@ internal class ActionProcessor
         {
             throw new NotImplementedException();
         }
-    }
-
-    private static IAudioDeviceSession FindForegroundApp(ObservableCollection<IAudioDeviceSession> groups)
-    {
-        var hWnd = PInvoke.GetForegroundWindow();
-        if (hWnd == (HWND)null)
-        {
-            Trace.WriteLine($"ActionProcessor FindForegroundApp: No Window (1)");
-            return null;
-        }
-
-        var className = string.Empty;
-        unsafe
-        {
-            Span<char> classNameBuffer = stackalloc char[(int)PInvoke.MAX_CLASS_NAME_LEN];
-            fixed (char* pClassNameBuffer = classNameBuffer)
-            {
-                _ = PInvoke.GetClassName(hWnd, pClassNameBuffer, classNameBuffer.Length);
-                className = new PWSTR(pClassNameBuffer).ToString();
-            }
-        }
-
-        // ApplicationFrameWindow.exe, find the real hosted process in the child CoreWindow.
-        if (className.ToString() == "ApplicationFrameWindow")
-        {
-            hWnd = PInvoke.FindWindowEx(hWnd, (HWND)null, "Windows.UI.Core.CoreWindow", null);
-        }
-        if (hWnd == (HWND)null)
-        {
-            Trace.WriteLine($"ActionProcessor FindForegroundApp: No Window (2)");
-            return null;
-        }
-
-        var processId = 0U;
-        unsafe
-        {
-            _ = PInvoke.GetWindowThreadProcessId(hWnd, &processId);
-        }
-
-        try
-        {
-            var appInfo = AppInformationFactory.CreateForProcess(processId);
-
-            foreach(var group in groups)
-            {
-                if (group.AppId == appInfo.PackageInstallPath || group.AppId == appInfo.AppId)
-                {
-                    Trace.WriteLine($"ActionProcessor FindForegroundApp: {group.DisplayName}");
-                    return group;
-                }
-            }
-        }
-        catch(Exception ex)
-        {
-            Trace.WriteLine(ex);
-        }
-        Trace.WriteLine("ActionProcessor FindForegroundApp Didn't locate foreground app");
-        return null;
     }
 
     private static void DoAudioAction(MuteKind action, IStreamWithVolumeControl stream)

--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -1,3 +1,4 @@
+using EarTrumpet.DataModel.Audio;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -57,6 +58,7 @@ public sealed partial class App : IDisposable
     private static readonly Stopwatch s_appTimer = Stopwatch.StartNew();
     private FlyoutViewModel _flyoutViewModel;
 
+    private const int c_focusedAppVolumeStep = 2;
     private ShellNotifyIcon _trayIcon;
     private WindowHolder _mixerWindow;
     private WindowHolder _settingsWindow;
@@ -150,6 +152,9 @@ public sealed partial class App : IDisposable
         Settings.SettingsHotkeyTyped += () => _settingsWindow.OpenOrBringToFront();
         Settings.AbsoluteVolumeUpHotkeyTyped += AbsoluteVolumeIncrement;
         Settings.AbsoluteVolumeDownHotkeyTyped += AbsoluteVolumeDecrement;
+        Settings.FocusedAppVolumeUpHotkeyTyped += FocusedAppVolumeIncrement;
+        Settings.FocusedAppVolumeDownHotkeyTyped += FocusedAppVolumeDecrement;
+        Settings.FocusedAppToggleMuteHotkeyTyped += FocusedAppToggleMute;
         Settings.RegisterHotkeys();
         Settings.UseLogarithmicVolumeChanged += (_, __) => UpdateTrayTooltip();
 
@@ -427,5 +432,52 @@ public sealed partial class App : IDisposable
                 device.IsAbsMuted = true;
             }
         }
+    }
+
+    private void FocusedAppVolumeIncrement()
+    {
+        ChangeFocusedAppVolume(c_focusedAppVolumeStep);
+    }
+
+    private void FocusedAppVolumeDecrement()
+    {
+        ChangeFocusedAppVolume(-c_focusedAppVolumeStep);
+    }
+
+    private void ChangeFocusedAppVolume(int delta)
+    {
+        foreach (var app in GetFocusedApps())
+        {
+            app.Volume = Math.Max(0, Math.Min(100, app.Volume + delta));
+        }
+    }
+
+    private void FocusedAppToggleMute()
+    {
+        var apps = GetFocusedApps().ToArray();
+        if (!apps.Any())
+        {
+            return;
+        }
+
+        var shouldMute = apps.Any(app => !app.IsMuted);
+        foreach (var app in apps)
+        {
+            app.IsMuted = shouldMute;
+        }
+    }
+
+    private IEnumerable<IAppItemViewModel> GetFocusedApps()
+    {
+        var foregroundAppIds = ForegroundAppResolver.TryGetForegroundAppIds();
+        if (foregroundAppIds.Count == 0)
+        {
+            return Enumerable.Empty<IAppItemViewModel>();
+        }
+
+        return CollectionViewModel.AllDevices
+            .SelectMany(device => device.Apps)
+            .Where(app => foregroundAppIds.Contains(app.AppId))
+            .ToArray();
     }
 }

--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -58,7 +58,8 @@ public sealed partial class App : IDisposable
     private static readonly Stopwatch s_appTimer = Stopwatch.StartNew();
     private FlyoutViewModel _flyoutViewModel;
 
-    private const int c_focusedAppVolumeStep = 2;
+    private const float c_focusedAppLinearVolumeStep = 2f;
+    private const float c_focusedAppLogarithmicVolumeStepDb = 0.5f;
     private ShellNotifyIcon _trayIcon;
     private WindowHolder _mixerWindow;
     private WindowHolder _settingsWindow;
@@ -436,19 +437,27 @@ public sealed partial class App : IDisposable
 
     private void FocusedAppVolumeIncrement()
     {
-        ChangeFocusedAppVolume(c_focusedAppVolumeStep);
+        ChangeFocusedAppVolume(GetFocusedAppVolumeStep());
     }
 
     private void FocusedAppVolumeDecrement()
     {
-        ChangeFocusedAppVolume(-c_focusedAppVolumeStep);
+        ChangeFocusedAppVolume(-GetFocusedAppVolumeStep());
     }
 
-    private void ChangeFocusedAppVolume(int delta)
+    private static float GetFocusedAppVolumeStep() => Settings.UseLogarithmicVolume
+        ? c_focusedAppLogarithmicVolumeStepDb
+        : c_focusedAppLinearVolumeStep;
+
+    private void ChangeFocusedAppVolume(float delta)
     {
+        var minimum = Settings.UseLogarithmicVolume ? Settings.LogarithmicVolumeMinDb : 0f;
+        var maximum = Settings.UseLogarithmicVolume ? 0f : 100f;
+
         foreach (var app in GetFocusedApps())
         {
-            app.Volume = Math.Max(0, Math.Min(100, app.Volume + delta));
+            var currentVolume = float.IsFinite(app.Volume) ? app.Volume : minimum;
+            app.Volume = Math.Clamp(currentVolume + delta, minimum, maximum);
         }
     }
 

--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -454,26 +454,12 @@ public sealed partial class App : IDisposable
         var minimum = Settings.UseLogarithmicVolume ? Settings.LogarithmicVolumeMinDb : 0f;
         var maximum = Settings.UseLogarithmicVolume ? 0f : 100f;
 
-        foreach (var app in GetFocusedApps())
-        {
-            var currentVolume = float.IsFinite(app.Volume) ? app.Volume : minimum;
-            app.Volume = Math.Clamp(currentVolume + delta, minimum, maximum);
-        }
+        FocusedAppAudioControl.ChangeVolume(GetFocusedApps(), delta, minimum, maximum);
     }
 
     private void FocusedAppToggleMute()
     {
-        var apps = GetFocusedApps().ToArray();
-        if (!apps.Any())
-        {
-            return;
-        }
-
-        var shouldMute = apps.Any(app => !app.IsMuted);
-        foreach (var app in apps)
-        {
-            app.IsMuted = shouldMute;
-        }
+        FocusedAppAudioControl.ToggleMute(GetFocusedApps());
     }
 
     private IEnumerable<IAppItemViewModel> GetFocusedApps()

--- a/EarTrumpet/App.xaml.cs
+++ b/EarTrumpet/App.xaml.cs
@@ -469,7 +469,8 @@ public sealed partial class App : IDisposable
 
     private IEnumerable<IAppItemViewModel> GetFocusedApps()
     {
-        var foregroundAppIds = ForegroundAppResolver.TryGetForegroundAppIds();
+        var foregroundAppIds = ForegroundAppResolver.TryGetForegroundAppIds(
+            CollectionViewModel.AllDevices.SelectMany(device => device.AudioSessions));
         if (foregroundAppIds.Count == 0)
         {
             return Enumerable.Empty<IAppItemViewModel>();

--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -16,6 +16,9 @@ public class AppSettings
     public event Action SettingsHotkeyTyped;
     public event Action AbsoluteVolumeUpHotkeyTyped;
     public event Action AbsoluteVolumeDownHotkeyTyped;
+    public event Action FocusedAppVolumeUpHotkeyTyped;
+    public event Action FocusedAppVolumeDownHotkeyTyped;
+    public event Action FocusedAppToggleMuteHotkeyTyped;
 
     private readonly ISettingsBag _settings = StorageFactory.GetSettings();
 
@@ -26,6 +29,9 @@ public class AppSettings
         HotkeyManager.Current.Register(SettingsHotkey);
         HotkeyManager.Current.Register(AbsoluteVolumeUpHotkey);
         HotkeyManager.Current.Register(AbsoluteVolumeDownHotkey);
+        HotkeyManager.Current.Register(FocusedAppVolumeUpHotkey);
+        HotkeyManager.Current.Register(FocusedAppVolumeDownHotkey);
+        HotkeyManager.Current.Register(FocusedAppToggleMuteHotkey);
 
         HotkeyManager.Current.KeyPressed += (hotkey) =>
         {
@@ -53,6 +59,21 @@ public class AppSettings
             {
                 Trace.WriteLine("AppSettings AbsoluteVolumeDownHotkeyTyped");
                 AbsoluteVolumeDownHotkeyTyped?.Invoke();
+            }
+            else if (hotkey.Equals(FocusedAppVolumeUpHotkey))
+            {
+                Trace.WriteLine("AppSettings FocusedAppVolumeUpHotkeyTyped");
+                FocusedAppVolumeUpHotkeyTyped?.Invoke();
+            }
+            else if (hotkey.Equals(FocusedAppVolumeDownHotkey))
+            {
+                Trace.WriteLine("AppSettings FocusedAppVolumeDownHotkeyTyped");
+                FocusedAppVolumeDownHotkeyTyped?.Invoke();
+            }
+            else if (hotkey.Equals(FocusedAppToggleMuteHotkey))
+            {
+                Trace.WriteLine("AppSettings FocusedAppToggleMuteHotkeyTyped");
+                FocusedAppToggleMuteHotkeyTyped?.Invoke();
             }
         };
     }
@@ -109,6 +130,39 @@ public class AppSettings
             HotkeyManager.Current.Unregister(AbsoluteVolumeDownHotkey);
             _settings.Set("AbsoluteVolumeDownHotkey", value);
             HotkeyManager.Current.Register(AbsoluteVolumeDownHotkey);
+        }
+    }
+
+    public HotkeyData FocusedAppVolumeUpHotkey
+    {
+        get => _settings.Get("FocusedAppVolumeUpHotkey", new HotkeyData { });
+        set
+        {
+            HotkeyManager.Current.Unregister(FocusedAppVolumeUpHotkey);
+            _settings.Set("FocusedAppVolumeUpHotkey", value);
+            HotkeyManager.Current.Register(FocusedAppVolumeUpHotkey);
+        }
+    }
+
+    public HotkeyData FocusedAppVolumeDownHotkey
+    {
+        get => _settings.Get("FocusedAppVolumeDownHotkey", new HotkeyData { });
+        set
+        {
+            HotkeyManager.Current.Unregister(FocusedAppVolumeDownHotkey);
+            _settings.Set("FocusedAppVolumeDownHotkey", value);
+            HotkeyManager.Current.Register(FocusedAppVolumeDownHotkey);
+        }
+    }
+
+    public HotkeyData FocusedAppToggleMuteHotkey
+    {
+        get => _settings.Get("FocusedAppToggleMuteHotkey", new HotkeyData { });
+        set
+        {
+            HotkeyManager.Current.Unregister(FocusedAppToggleMuteHotkey);
+            _settings.Set("FocusedAppToggleMuteHotkey", value);
+            HotkeyManager.Current.Register(FocusedAppToggleMuteHotkey);
         }
     }
 

--- a/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
+++ b/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
@@ -1,0 +1,97 @@
+using EarTrumpet.DataModel.AppInformation;
+using EarTrumpet.Interop;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace EarTrumpet.DataModel.Audio
+{
+    public static class ForegroundAppResolver
+    {
+        public static IReadOnlyList<string> TryGetForegroundAppIds()
+        {
+            var hWnd = User32.GetForegroundWindow();
+            var foregroundClassName = new StringBuilder(User32.MAX_CLASSNAME_LENGTH);
+            User32.GetClassName(hWnd, foregroundClassName, foregroundClassName.Capacity);
+
+            if (hWnd == IntPtr.Zero)
+            {
+                Trace.WriteLine("ForegroundAppResolver: No Window (1)");
+                return Array.Empty<string>();
+            }
+
+            if (foregroundClassName.ToString() == "ApplicationFrameWindow")
+            {
+                hWnd = User32.FindWindowEx(hWnd, IntPtr.Zero, "Windows.UI.Core.CoreWindow", IntPtr.Zero);
+            }
+
+            if (hWnd == IntPtr.Zero)
+            {
+                Trace.WriteLine("ForegroundAppResolver: No Window (2)");
+                return Array.Empty<string>();
+            }
+
+            User32.GetWindowThreadProcessId(hWnd, out uint processId);
+
+            try
+            {
+                var appInfo = AppInformationFactory.CreateForProcess((int)processId);
+                return new[] { appInfo.PackageInstallPath, appInfo.AppId }
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Distinct()
+                    .ToArray();
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(ex);
+                return Array.Empty<string>();
+            }
+        }
+
+        public static IAudioDeviceSession FindForegroundApp(ObservableCollection<IAudioDeviceSession> groups)
+        {
+            var foregroundAppIds = TryGetForegroundAppIds();
+            if (foregroundAppIds.Count == 0)
+            {
+                return null;
+            }
+
+            var group = groups.FirstOrDefault(candidate => foregroundAppIds.Contains(candidate.AppId));
+            if (group != null)
+            {
+                Trace.WriteLine($"ForegroundAppResolver: {group.DisplayName}");
+            }
+            else
+            {
+                Trace.WriteLine("ForegroundAppResolver: Didn't locate foreground app");
+            }
+
+            return group;
+        }
+
+        public static IAudioDeviceSession FindForegroundApp(IEnumerable<IAudioDevice> devices)
+        {
+            var foregroundAppIds = TryGetForegroundAppIds();
+            if (foregroundAppIds.Count == 0)
+            {
+                return null;
+            }
+
+            foreach (var device in devices)
+            {
+                var group = device.Groups.FirstOrDefault(candidate => foregroundAppIds.Contains(candidate.AppId));
+                if (group != null)
+                {
+                    Trace.WriteLine($"ForegroundAppResolver: {group.DisplayName}");
+                    return group;
+                }
+            }
+
+            Trace.WriteLine("ForegroundAppResolver: Didn't locate foreground app");
+            return null;
+        }
+    }
+}

--- a/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
+++ b/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
@@ -1,11 +1,11 @@
 using EarTrumpet.DataModel.AppInformation;
-using EarTrumpet.Interop;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace EarTrumpet.DataModel.Audio
 {
@@ -13,41 +13,55 @@ namespace EarTrumpet.DataModel.Audio
     {
         public static IReadOnlyList<string> TryGetForegroundAppIds()
         {
-            var hWnd = User32.GetForegroundWindow();
-            var foregroundClassName = new StringBuilder(User32.MAX_CLASSNAME_LENGTH);
-            User32.GetClassName(hWnd, foregroundClassName, foregroundClassName.Capacity);
-
-            if (hWnd == IntPtr.Zero)
+            var hWnd = PInvoke.GetForegroundWindow();
+            if (hWnd == (HWND)null)
             {
                 Trace.WriteLine("ForegroundAppResolver: No Window (1)");
                 return Array.Empty<string>();
             }
 
-            if (foregroundClassName.ToString() == "ApplicationFrameWindow")
+            var maxClassNameLength = (int)PInvoke.MAX_CLASS_NAME_LEN;
+            Span<char> foregroundClassNameBuffer = stackalloc char[maxClassNameLength];
+            foregroundClassNameBuffer.Clear();
+            string foregroundClassName;
+            unsafe
             {
-                hWnd = User32.FindWindowEx(hWnd, IntPtr.Zero, "Windows.UI.Core.CoreWindow", IntPtr.Zero);
+                fixed (char* foregroundClassNamePtr = foregroundClassNameBuffer)
+                {
+                    PInvoke.GetClassName(hWnd, foregroundClassNamePtr, maxClassNameLength);
+                    foregroundClassName = new PWSTR(foregroundClassNamePtr).ToString();
+                }
             }
 
-            if (hWnd == IntPtr.Zero)
+            if (foregroundClassName == "ApplicationFrameWindow")
+            {
+                hWnd = PInvoke.FindWindowEx(hWnd, (HWND)null, "Windows.UI.Core.CoreWindow", null);
+            }
+
+            if (hWnd == (HWND)null)
             {
                 Trace.WriteLine("ForegroundAppResolver: No Window (2)");
                 return Array.Empty<string>();
             }
 
-            User32.GetWindowThreadProcessId(hWnd, out uint processId);
+            unsafe
+            {
+                uint processId;
+                PInvoke.GetWindowThreadProcessId(hWnd, &processId);
 
-            try
-            {
-                var appInfo = AppInformationFactory.CreateForProcess((int)processId);
-                return new[] { appInfo.PackageInstallPath, appInfo.AppId }
-                    .Where(value => !string.IsNullOrWhiteSpace(value))
-                    .Distinct()
-                    .ToArray();
-            }
-            catch (Exception ex)
-            {
-                Trace.WriteLine(ex);
-                return Array.Empty<string>();
+                try
+                {
+                    var appInfo = AppInformationFactory.CreateForProcess(processId);
+                    return new[] { appInfo.PackageInstallPath, appInfo.AppId }
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Distinct()
+                        .ToArray();
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine(ex);
+                    return Array.Empty<string>();
+                }
             }
         }
 

--- a/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
+++ b/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
@@ -13,6 +13,18 @@ namespace EarTrumpet.DataModel.Audio
 {
     public static class ForegroundAppResolver
     {
+        internal readonly struct ProcessSnapshotEntry
+        {
+            public uint ParentProcessId { get; }
+            public long CreationTime { get; }
+
+            public ProcessSnapshotEntry(uint parentProcessId, long creationTime)
+            {
+                ParentProcessId = parentProcessId;
+                CreationTime = creationTime;
+            }
+        }
+
         internal readonly struct SessionCandidate
         {
             public uint ProcessId { get; }
@@ -46,7 +58,7 @@ namespace EarTrumpet.DataModel.Audio
                 .ToArray();
             var activeDescendantAppIds = GetActiveDescendantAppIds(
                 foregroundProcessId,
-                TryGetParentProcessIds(),
+                TryGetProcessSnapshot(),
                 candidates);
 
             if (activeDescendantAppIds.Count == 1)
@@ -131,7 +143,7 @@ namespace EarTrumpet.DataModel.Audio
             return true;
         }
 
-        private static IEnumerable<SessionCandidate> EnumerateSessionCandidates(IEnumerable<IAudioDeviceSession> groups)
+        internal static IEnumerable<SessionCandidate> EnumerateSessionCandidates(IEnumerable<IAudioDeviceSession> groups)
         {
             if (groups == null)
             {
@@ -140,27 +152,40 @@ namespace EarTrumpet.DataModel.Audio
 
             foreach (var group in groups.Where(group => group != null).ToArray())
             {
-                var sessions = group.Children?.ToArray();
-                if (sessions?.Length > 0)
+                foreach (var candidate in EnumerateSessionCandidates(group, group.AppId))
                 {
-                    foreach (var session in sessions.Where(session => session != null))
+                    yield return candidate;
+                }
+            }
+        }
+
+        private static IEnumerable<SessionCandidate> EnumerateSessionCandidates(IAudioDeviceSession session, string appId)
+        {
+            var children = session.Children?.ToArray();
+            if (children?.Length > 0)
+            {
+                // Both app groups and grouping-parameter groups aggregate state and borrow
+                // the first child's process ID. Only leaves describe an actual stream.
+                foreach (var child in children.Where(child => child != null))
+                {
+                    foreach (var candidate in EnumerateSessionCandidates(child, appId))
                     {
-                        yield return new SessionCandidate(session.ProcessId, group.AppId, session.State);
+                        yield return candidate;
                     }
                 }
-                else
-                {
-                    yield return new SessionCandidate(group.ProcessId, group.AppId, group.State);
-                }
+            }
+            else
+            {
+                yield return new SessionCandidate(session.ProcessId, appId, session.State);
             }
         }
 
         internal static IReadOnlyList<string> GetActiveDescendantAppIds(
             uint foregroundProcessId,
-            IReadOnlyDictionary<uint, uint> parentProcessIds,
+            IReadOnlyDictionary<uint, ProcessSnapshotEntry> processes,
             IEnumerable<SessionCandidate> candidates)
         {
-            if (foregroundProcessId == 0 || parentProcessIds == null || candidates == null)
+            if (foregroundProcessId == 0 || processes == null || candidates == null)
             {
                 return Array.Empty<string>();
             }
@@ -168,7 +193,7 @@ namespace EarTrumpet.DataModel.Audio
             return candidates
                 .Where(candidate => candidate.State == SessionState.Active &&
                                     !string.IsNullOrWhiteSpace(candidate.AppId) &&
-                                    IsStrictDescendant(candidate.ProcessId, foregroundProcessId, parentProcessIds))
+                                    IsStrictDescendant(candidate.ProcessId, foregroundProcessId, processes))
                 .Select(candidate => candidate.AppId)
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(appId => appId, StringComparer.Ordinal)
@@ -178,7 +203,7 @@ namespace EarTrumpet.DataModel.Audio
         private static bool IsStrictDescendant(
             uint processId,
             uint ancestorProcessId,
-            IReadOnlyDictionary<uint, uint> parentProcessIds)
+            IReadOnlyDictionary<uint, ProcessSnapshotEntry> processes)
         {
             if (processId == 0 || processId == ancestorProcessId)
             {
@@ -189,23 +214,31 @@ namespace EarTrumpet.DataModel.Audio
             var currentProcessId = processId;
             while (currentProcessId != 0 && visitedProcessIds.Add(currentProcessId))
             {
-                if (!parentProcessIds.TryGetValue(currentProcessId, out var parentProcessId))
+                if (!processes.TryGetValue(currentProcessId, out var process) ||
+                    !processes.TryGetValue(process.ParentProcessId, out var parent))
                 {
                     return false;
                 }
 
-                if (parentProcessId == ancestorProcessId)
+                // Windows retains the original parent PID after it exits. A newer
+                // process with that reused PID cannot be this process's parent.
+                if (parent.CreationTime > process.CreationTime)
+                {
+                    return false;
+                }
+
+                if (process.ParentProcessId == ancestorProcessId)
                 {
                     return true;
                 }
 
-                currentProcessId = parentProcessId;
+                currentProcessId = process.ParentProcessId;
             }
 
             return false;
         }
 
-        private static IReadOnlyDictionary<uint, uint> TryGetParentProcessIds()
+        private static IReadOnlyDictionary<uint, ProcessSnapshotEntry> TryGetProcessSnapshot()
         {
             const int maxAttempts = 3;
             const int bufferPadding = 64 * 1024;
@@ -221,7 +254,7 @@ namespace EarTrumpet.DataModel.Audio
                 if (status != Ntdll.NTSTATUS.STATUS_INFO_LENGTH_MISMATCH || requiredBufferLength <= 0)
                 {
                     Trace.WriteLine($"ForegroundAppResolver: Failed to size process snapshot ({status})");
-                    return new Dictionary<uint, uint>();
+                    return new Dictionary<uint, ProcessSnapshotEntry>();
                 }
 
                 var bufferLength = requiredBufferLength + bufferPadding;
@@ -241,10 +274,10 @@ namespace EarTrumpet.DataModel.Audio
                     if (status != Ntdll.NTSTATUS.SUCCESS)
                     {
                         Trace.WriteLine($"ForegroundAppResolver: Failed to read process snapshot ({status})");
-                        return new Dictionary<uint, uint>();
+                        return new Dictionary<uint, ProcessSnapshotEntry>();
                     }
 
-                    var parentProcessIds = new Dictionary<uint, uint>();
+                    var processes = new Dictionary<uint, ProcessSnapshotEntry>();
                     var entryPointer = buffer;
                     Ntdll.SYSTEM_PROCESS_INFORMATION processInfo;
                     do
@@ -254,13 +287,13 @@ namespace EarTrumpet.DataModel.Audio
                         var parentProcessId = unchecked((uint)processInfo.InheritedFromUniqueProcessId);
                         if (currentProcessId != 0)
                         {
-                            parentProcessIds[currentProcessId] = parentProcessId;
+                            processes[currentProcessId] = new ProcessSnapshotEntry(parentProcessId, processInfo.CreateTime);
                         }
 
                         entryPointer += processInfo.NextEntryOffset;
                     } while (processInfo.NextEntryOffset != 0);
 
-                    return parentProcessIds;
+                    return processes;
                 }
                 finally
                 {
@@ -269,7 +302,7 @@ namespace EarTrumpet.DataModel.Audio
             }
 
             Trace.WriteLine("ForegroundAppResolver: Process snapshot kept changing; using foreground app");
-            return new Dictionary<uint, uint>();
+            return new Dictionary<uint, ProcessSnapshotEntry>();
         }
 
         public static IAudioDeviceSession FindForegroundApp(ObservableCollection<IAudioDeviceSession> groups)

--- a/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
+++ b/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
@@ -1,9 +1,11 @@
 using EarTrumpet.DataModel.AppInformation;
+using EarTrumpet.Interop;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 
@@ -11,13 +13,70 @@ namespace EarTrumpet.DataModel.Audio
 {
     public static class ForegroundAppResolver
     {
+        internal readonly struct SessionCandidate
+        {
+            public uint ProcessId { get; }
+            public string AppId { get; }
+            public SessionState State { get; }
+
+            public SessionCandidate(uint processId, string appId, SessionState state)
+            {
+                ProcessId = processId;
+                AppId = appId;
+                State = state;
+            }
+        }
+
         public static IReadOnlyList<string> TryGetForegroundAppIds()
         {
+            TryGetForegroundProcess(out _, out var foregroundAppIds);
+            return foregroundAppIds;
+        }
+
+        public static IReadOnlyList<string> TryGetForegroundAppIds(IEnumerable<IAudioDeviceSession> groups)
+        {
+            if (!TryGetForegroundProcess(out var foregroundProcessId, out var foregroundAppIds))
+            {
+                return foregroundAppIds;
+            }
+
+            var foregroundAppIdSet = foregroundAppIds.ToHashSet(StringComparer.Ordinal);
+            var candidates = EnumerateSessionCandidates(groups)
+                .Where(candidate => !foregroundAppIdSet.Contains(candidate.AppId))
+                .ToArray();
+            var activeDescendantAppIds = GetActiveDescendantAppIds(
+                foregroundProcessId,
+                TryGetParentProcessIds(),
+                candidates);
+
+            if (activeDescendantAppIds.Count == 1)
+            {
+                Trace.WriteLine($"ForegroundAppResolver: Selected active descendant app {activeDescendantAppIds[0]}");
+                return activeDescendantAppIds;
+            }
+
+            if (activeDescendantAppIds.Count > 1)
+            {
+                Trace.WriteLine($"ForegroundAppResolver: Found {activeDescendantAppIds.Count} active descendant apps; using foreground app");
+            }
+            else
+            {
+                Trace.WriteLine("ForegroundAppResolver: No active descendant app; using foreground app");
+            }
+
+            return foregroundAppIds;
+        }
+
+        private static bool TryGetForegroundProcess(out uint processId, out IReadOnlyList<string> appIds)
+        {
+            processId = 0;
+            appIds = Array.Empty<string>();
+
             var hWnd = PInvoke.GetForegroundWindow();
             if (hWnd == (HWND)null)
             {
                 Trace.WriteLine("ForegroundAppResolver: No Window (1)");
-                return Array.Empty<string>();
+                return false;
             }
 
             var maxClassNameLength = (int)PInvoke.MAX_CLASS_NAME_LEN;
@@ -41,39 +100,188 @@ namespace EarTrumpet.DataModel.Audio
             if (hWnd == (HWND)null)
             {
                 Trace.WriteLine("ForegroundAppResolver: No Window (2)");
-                return Array.Empty<string>();
+                return false;
             }
 
             unsafe
             {
-                uint processId;
-                PInvoke.GetWindowThreadProcessId(hWnd, &processId);
-
-                try
+                uint resolvedProcessId;
+                if (PInvoke.GetWindowThreadProcessId(hWnd, &resolvedProcessId) == 0 || resolvedProcessId == 0)
                 {
-                    var appInfo = AppInformationFactory.CreateForProcess(processId);
-                    return new[] { appInfo.PackageInstallPath, appInfo.AppId }
-                        .Where(value => !string.IsNullOrWhiteSpace(value))
-                        .Distinct()
-                        .ToArray();
+                    Trace.WriteLine("ForegroundAppResolver: No foreground process");
+                    return false;
                 }
-                catch (Exception ex)
+
+                processId = resolvedProcessId;
+            }
+
+            try
+            {
+                var appInfo = AppInformationFactory.CreateForProcess(processId);
+                appIds = new[] { appInfo.PackageInstallPath, appInfo.AppId }
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(ex);
+            }
+
+            return true;
+        }
+
+        private static IEnumerable<SessionCandidate> EnumerateSessionCandidates(IEnumerable<IAudioDeviceSession> groups)
+        {
+            if (groups == null)
+            {
+                yield break;
+            }
+
+            foreach (var group in groups.Where(group => group != null).ToArray())
+            {
+                var sessions = group.Children?.ToArray();
+                if (sessions?.Length > 0)
                 {
-                    Trace.WriteLine(ex);
-                    return Array.Empty<string>();
+                    foreach (var session in sessions.Where(session => session != null))
+                    {
+                        yield return new SessionCandidate(session.ProcessId, group.AppId, session.State);
+                    }
+                }
+                else
+                {
+                    yield return new SessionCandidate(group.ProcessId, group.AppId, group.State);
                 }
             }
         }
 
+        internal static IReadOnlyList<string> GetActiveDescendantAppIds(
+            uint foregroundProcessId,
+            IReadOnlyDictionary<uint, uint> parentProcessIds,
+            IEnumerable<SessionCandidate> candidates)
+        {
+            if (foregroundProcessId == 0 || parentProcessIds == null || candidates == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            return candidates
+                .Where(candidate => candidate.State == SessionState.Active &&
+                                    !string.IsNullOrWhiteSpace(candidate.AppId) &&
+                                    IsStrictDescendant(candidate.ProcessId, foregroundProcessId, parentProcessIds))
+                .Select(candidate => candidate.AppId)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(appId => appId, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static bool IsStrictDescendant(
+            uint processId,
+            uint ancestorProcessId,
+            IReadOnlyDictionary<uint, uint> parentProcessIds)
+        {
+            if (processId == 0 || processId == ancestorProcessId)
+            {
+                return false;
+            }
+
+            var visitedProcessIds = new HashSet<uint>();
+            var currentProcessId = processId;
+            while (currentProcessId != 0 && visitedProcessIds.Add(currentProcessId))
+            {
+                if (!parentProcessIds.TryGetValue(currentProcessId, out var parentProcessId))
+                {
+                    return false;
+                }
+
+                if (parentProcessId == ancestorProcessId)
+                {
+                    return true;
+                }
+
+                currentProcessId = parentProcessId;
+            }
+
+            return false;
+        }
+
+        private static IReadOnlyDictionary<uint, uint> TryGetParentProcessIds()
+        {
+            const int maxAttempts = 3;
+            const int bufferPadding = 64 * 1024;
+
+            for (var attempt = 0; attempt < maxAttempts; attempt++)
+            {
+                var status = Ntdll.NtQuerySystemInformationInitial(
+                    Ntdll.SYSTEM_INFORMATION_CLASS.SystemProcessInformation,
+                    IntPtr.Zero,
+                    0,
+                    out var requiredBufferLength);
+
+                if (status != Ntdll.NTSTATUS.STATUS_INFO_LENGTH_MISMATCH || requiredBufferLength <= 0)
+                {
+                    Trace.WriteLine($"ForegroundAppResolver: Failed to size process snapshot ({status})");
+                    return new Dictionary<uint, uint>();
+                }
+
+                var bufferLength = requiredBufferLength + bufferPadding;
+                var buffer = Marshal.AllocHGlobal(bufferLength);
+                try
+                {
+                    status = Ntdll.NtQuerySystemInformation(
+                        Ntdll.SYSTEM_INFORMATION_CLASS.SystemProcessInformation,
+                        buffer,
+                        bufferLength,
+                        IntPtr.Zero);
+                    if (status == Ntdll.NTSTATUS.STATUS_INFO_LENGTH_MISMATCH)
+                    {
+                        continue;
+                    }
+
+                    if (status != Ntdll.NTSTATUS.SUCCESS)
+                    {
+                        Trace.WriteLine($"ForegroundAppResolver: Failed to read process snapshot ({status})");
+                        return new Dictionary<uint, uint>();
+                    }
+
+                    var parentProcessIds = new Dictionary<uint, uint>();
+                    var entryPointer = buffer;
+                    Ntdll.SYSTEM_PROCESS_INFORMATION processInfo;
+                    do
+                    {
+                        processInfo = Marshal.PtrToStructure<Ntdll.SYSTEM_PROCESS_INFORMATION>(entryPointer);
+                        var currentProcessId = unchecked((uint)processInfo.UniqueProcessId);
+                        var parentProcessId = unchecked((uint)processInfo.InheritedFromUniqueProcessId);
+                        if (currentProcessId != 0)
+                        {
+                            parentProcessIds[currentProcessId] = parentProcessId;
+                        }
+
+                        entryPointer += processInfo.NextEntryOffset;
+                    } while (processInfo.NextEntryOffset != 0);
+
+                    return parentProcessIds;
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(buffer);
+                }
+            }
+
+            Trace.WriteLine("ForegroundAppResolver: Process snapshot kept changing; using foreground app");
+            return new Dictionary<uint, uint>();
+        }
+
         public static IAudioDeviceSession FindForegroundApp(ObservableCollection<IAudioDeviceSession> groups)
         {
-            var foregroundAppIds = TryGetForegroundAppIds();
+            var groupSnapshot = groups?.Where(group => group != null).ToArray() ?? Array.Empty<IAudioDeviceSession>();
+            var foregroundAppIds = TryGetForegroundAppIds(groupSnapshot);
             if (foregroundAppIds.Count == 0)
             {
                 return null;
             }
 
-            var group = groups.FirstOrDefault(candidate => foregroundAppIds.Contains(candidate.AppId));
+            var group = groupSnapshot.FirstOrDefault(candidate => foregroundAppIds.Contains(candidate.AppId));
             if (group != null)
             {
                 Trace.WriteLine($"ForegroundAppResolver: {group.DisplayName}");
@@ -88,13 +296,15 @@ namespace EarTrumpet.DataModel.Audio
 
         public static IAudioDeviceSession FindForegroundApp(IEnumerable<IAudioDevice> devices)
         {
-            var foregroundAppIds = TryGetForegroundAppIds();
+            var deviceSnapshot = devices?.Where(device => device != null).ToArray() ?? Array.Empty<IAudioDevice>();
+            var groupSnapshot = deviceSnapshot.SelectMany(device => device.Groups).ToArray();
+            var foregroundAppIds = TryGetForegroundAppIds(groupSnapshot);
             if (foregroundAppIds.Count == 0)
             {
                 return null;
             }
 
-            foreach (var device in devices)
+            foreach (var device in deviceSnapshot)
             {
                 var group = device.Groups.FirstOrDefault(candidate => foregroundAppIds.Contains(candidate.AppId));
                 if (group != null)

--- a/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
+++ b/EarTrumpet/DataModel/Audio/ForegroundAppResolver.cs
@@ -294,28 +294,5 @@ namespace EarTrumpet.DataModel.Audio
             return group;
         }
 
-        public static IAudioDeviceSession FindForegroundApp(IEnumerable<IAudioDevice> devices)
-        {
-            var deviceSnapshot = devices?.Where(device => device != null).ToArray() ?? Array.Empty<IAudioDevice>();
-            var groupSnapshot = deviceSnapshot.SelectMany(device => device.Groups).ToArray();
-            var foregroundAppIds = TryGetForegroundAppIds(groupSnapshot);
-            if (foregroundAppIds.Count == 0)
-            {
-                return null;
-            }
-
-            foreach (var device in deviceSnapshot)
-            {
-                var group = device.Groups.FirstOrDefault(candidate => foregroundAppIds.Contains(candidate.AppId));
-                if (group != null)
-                {
-                    Trace.WriteLine($"ForegroundAppResolver: {group.DisplayName}");
-                    return group;
-                }
-            }
-
-            Trace.WriteLine("ForegroundAppResolver: Didn't locate foreground app");
-            return null;
-        }
     }
 }

--- a/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceSession.cs
+++ b/EarTrumpet/DataModel/WindowsAudio/Internal/AudioDeviceSession.cs
@@ -231,8 +231,10 @@ internal class AudioDeviceSession : BindableBase, IAudioSessionEvents, IAudioDev
     {
         value = value.Bound(App.Settings.LogarithmicVolumeMinDb, 0);
         // We must convert manually here because sessions use linear volume.
-        _simpleVolume.SetMasterVolume(value.LogToLinear(), Guid.Empty);
-        _volume = value;
+        var scalar = value.LogToLinear();
+        _simpleVolume.SetMasterVolume(scalar, Guid.Empty);
+        // Keep readback consistent before Core Audio's asynchronous callback arrives.
+        _volume = scalar;
         IsMuted = value <= App.Settings.LogarithmicVolumeMinDb;
     }
 

--- a/EarTrumpet/Interop/Ntdll.cs
+++ b/EarTrumpet/Interop/Ntdll.cs
@@ -19,6 +19,9 @@ internal class Ntdll
         [FieldOffset(0)]
         public int NextEntryOffset;
         /* ... */
+        [FieldOffset(32)]
+        public long CreateTime;
+        /* ... */
         [FieldOffset(56)]
         public UNICODE_STRING ImageName;
         /* ... */
@@ -34,6 +37,9 @@ internal class Ntdll
     {
         [FieldOffset(0)]
         public int NextEntryOffset;
+        /* ... */
+        [FieldOffset(32)]
+        public long CreateTime;
         /* ... */
         [FieldOffset(56)]
         public UNICODE_STRING ImageName;

--- a/EarTrumpet/Interop/Ntdll.cs
+++ b/EarTrumpet/Interop/Ntdll.cs
@@ -24,6 +24,8 @@ internal class Ntdll
         /* ... */
         [FieldOffset(68)]
         public int UniqueProcessId;
+        [FieldOffset(72)]
+        public int InheritedFromUniqueProcessId;
         /* ... */
     }
 #elif X64 || ARM64
@@ -38,6 +40,8 @@ internal class Ntdll
         /* ... */
         [FieldOffset(80)]
         public int UniqueProcessId;
+        [FieldOffset(88)]
+        public int InheritedFromUniqueProcessId;
         /* ... */
     }
 #else

--- a/EarTrumpet/Properties/AssemblyInfo.cs
+++ b/EarTrumpet/Properties/AssemblyInfo.cs
@@ -11,3 +11,4 @@ using System.Windows;
 [assembly: NeutralResourcesLanguage("en")]
 [assembly: SupportedOSPlatform("windows10.0.17763")]
 [assembly: InternalsVisibleTo("EarTrumpet.Benchmarks")]
+[assembly: InternalsVisibleTo("EarTrumpet.Tests")]

--- a/EarTrumpet/Properties/Resources.Designer.cs
+++ b/EarTrumpet/Properties/Resources.Designer.cs
@@ -1386,6 +1386,33 @@ namespace EarTrumpet.Properties {
                 return ResourceManager.GetString("SettingsAbsoluteVolumeUpText", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Decrease volume for the focused app.
+        /// </summary>
+        public static string SettingsFocusedAppVolumeDownText {
+            get {
+                return ResourceManager.GetString("SettingsFocusedAppVolumeDownText", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Increase volume for the focused app.
+        /// </summary>
+        public static string SettingsFocusedAppVolumeUpText {
+            get {
+                return ResourceManager.GetString("SettingsFocusedAppVolumeUpText", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Toggle mute for the focused app.
+        /// </summary>
+        public static string SettingsFocusedAppToggleMuteText {
+            get {
+                return ResourceManager.GetString("SettingsFocusedAppToggleMuteText", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to General.

--- a/EarTrumpet/Properties/Resources.resx
+++ b/EarTrumpet/Properties/Resources.resx
@@ -652,6 +652,15 @@ Open [https://eartrumpet.app/jmp/fixstartup] to resolve this?</value>
   <data name="SettingsAbsoluteVolumeUpText" xml:space="preserve">
     <value>Increase volume for all devices</value>
   </data>
+  <data name="SettingsFocusedAppVolumeDownText" xml:space="preserve">
+    <value>Decrease volume for the focused app</value>
+  </data>
+  <data name="SettingsFocusedAppVolumeUpText" xml:space="preserve">
+    <value>Increase volume for the focused app</value>
+  </data>
+  <data name="SettingsFocusedAppToggleMuteText" xml:space="preserve">
+    <value>Toggle mute for the focused app</value>
+  </data>
   <data name="OpenAppsVolume_Windows10_Text" xml:space="preserve">
     <value>App volume and device preferences</value>
   </data>

--- a/EarTrumpet/UI/Helpers/FocusedAppAudioControl.cs
+++ b/EarTrumpet/UI/Helpers/FocusedAppAudioControl.cs
@@ -1,0 +1,51 @@
+using EarTrumpet.UI.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EarTrumpet.UI.Helpers;
+
+internal static class FocusedAppAudioControl
+{
+    internal static void ChangeVolume(IEnumerable<IAppItemViewModel> apps, float delta, float minimum, float maximum)
+    {
+        foreach (var stream in EnumerateStreams(apps).ToArray())
+        {
+            var volume = stream.Volume;
+            var currentVolume = float.IsFinite(volume) ? volume : minimum;
+            stream.Volume = Math.Clamp(currentVolume + delta, minimum, maximum);
+        }
+    }
+
+    internal static void ToggleMute(IEnumerable<IAppItemViewModel> apps)
+    {
+        var streams = EnumerateStreams(apps).ToArray();
+        var shouldMute = streams.Any(stream => !stream.IsMuted);
+        foreach (var stream in streams)
+        {
+            stream.IsMuted = shouldMute;
+        }
+    }
+
+    private static IEnumerable<IAppItemViewModel> EnumerateStreams(IEnumerable<IAppItemViewModel> apps)
+    {
+        foreach (var app in apps)
+        {
+            var children = app.ChildApps?.ToArray();
+            if (children?.Length > 0)
+            {
+                // Group getters describe only the first stream, while setters affect every stream.
+                // Walk all grouping levels to preserve individual volumes and inspect every mute state.
+                foreach (var stream in EnumerateStreams(children))
+                {
+                    yield return stream;
+                }
+            }
+            else
+            {
+                // Include leaf placeholders so changes survive an inactive app's device move.
+                yield return app;
+            }
+        }
+    }
+}

--- a/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/DeviceViewModel.cs
@@ -69,6 +69,7 @@ public class DeviceViewModel : AudioSessionViewModel, IDeviceViewModel
     protected readonly IAudioDevice _device;
     protected readonly IAudioDeviceManager _deviceManager;
     protected readonly WeakReference<DeviceCollectionViewModel> _parent;
+    internal IEnumerable<IAudioDeviceSession> AudioSessions => _device.Groups;
     private bool _isDisplayNameVisible;
     private DeviceIconKind _iconKind;
 

--- a/EarTrumpet/UI/ViewModels/EarTrumpetShortcutsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetShortcutsPageViewModel.cs
@@ -21,6 +21,15 @@ internal class EarTrumpetShortcutsPageViewModel : SettingsPageViewModel
     public HotkeyViewModel AbsoluteVolumeDownHotkey { get; }
     public static string DefaultAbsoluteVolumeDownHotkey => s_hotkeyNoneText;
 
+    public HotkeyViewModel FocusedAppVolumeUpHotkey { get; }
+    public static string DefaultFocusedAppVolumeUpHotkey => s_hotkeyNoneText;
+
+    public HotkeyViewModel FocusedAppVolumeDownHotkey { get; }
+    public static string DefaultFocusedAppVolumeDownHotkey => s_hotkeyNoneText;
+
+    public HotkeyViewModel FocusedAppToggleMuteHotkey { get; }
+    public static string DefaultFocusedAppToggleMuteHotkey => s_hotkeyNoneText;
+
     public EarTrumpetShortcutsPageViewModel(AppSettings settings) : base(null)
     {
         Title = Properties.Resources.ShortcutsPageText;
@@ -31,5 +40,8 @@ internal class EarTrumpetShortcutsPageViewModel : SettingsPageViewModel
         OpenSettingsHotkey = new HotkeyViewModel(settings.SettingsHotkey, (newHotkey) => settings.SettingsHotkey = newHotkey);
         AbsoluteVolumeUpHotkey = new HotkeyViewModel(settings.AbsoluteVolumeUpHotkey, (newHotkey) => settings.AbsoluteVolumeUpHotkey = newHotkey);
         AbsoluteVolumeDownHotkey = new HotkeyViewModel(settings.AbsoluteVolumeDownHotkey, (newHotkey) => settings.AbsoluteVolumeDownHotkey = newHotkey);
+        FocusedAppVolumeUpHotkey = new HotkeyViewModel(settings.FocusedAppVolumeUpHotkey, (newHotkey) => settings.FocusedAppVolumeUpHotkey = newHotkey);
+        FocusedAppVolumeDownHotkey = new HotkeyViewModel(settings.FocusedAppVolumeDownHotkey, (newHotkey) => settings.FocusedAppVolumeDownHotkey = newHotkey);
+        FocusedAppToggleMuteHotkey = new HotkeyViewModel(settings.FocusedAppToggleMuteHotkey, (newHotkey) => settings.FocusedAppToggleMuteHotkey = newHotkey);
     }
 }

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -162,6 +162,84 @@
                                     Content="{Binding AbsoluteVolumeDownHotkey}"
                                     IsTabStop="False" />
                 </Grid>
+                <TextBlock Style="{StaticResource BodyText}" Text="{x:Static resx:Resources.SettingsFocusedAppVolumeUpText}" />
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.DefaultHotkeyDescriptionText}" />
+                    <TextBlock Grid.Column="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodyText}"
+                               Text="{Binding DefaultFocusedAppVolumeUpHotkey}" />
+                    <TextBlock Grid.Row="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.HotkeyDescriptionText}" />
+                    <ContentControl Grid.Row="1"
+                                    Grid.Column="1"
+                                    Content="{Binding FocusedAppVolumeUpHotkey}"
+                                    IsTabStop="False" />
+                </Grid>
+                <TextBlock Style="{StaticResource BodyText}" Text="{x:Static resx:Resources.SettingsFocusedAppVolumeDownText}" />
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.DefaultHotkeyDescriptionText}" />
+                    <TextBlock Grid.Column="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodyText}"
+                               Text="{Binding DefaultFocusedAppVolumeDownHotkey}" />
+                    <TextBlock Grid.Row="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.HotkeyDescriptionText}" />
+                    <ContentControl Grid.Row="1"
+                                    Grid.Column="1"
+                                    Content="{Binding FocusedAppVolumeDownHotkey}"
+                                    IsTabStop="False" />
+                </Grid>
+                <TextBlock Style="{StaticResource BodyText}" Text="{x:Static resx:Resources.SettingsFocusedAppToggleMuteText}" />
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.DefaultHotkeyDescriptionText}" />
+                    <TextBlock Grid.Column="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodyText}"
+                               Text="{Binding DefaultFocusedAppToggleMuteHotkey}" />
+                    <TextBlock Grid.Row="1"
+                               VerticalAlignment="Center"
+                               Style="{StaticResource BodySubText}"
+                               Text="{x:Static resx:Resources.HotkeyDescriptionText}" />
+                    <ContentControl Grid.Row="1"
+                                    Grid.Column="1"
+                                    Content="{Binding FocusedAppToggleMuteHotkey}"
+                                    IsTabStop="False" />
+                </Grid>
             </StackPanel>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:EarTrumpetMouseSettingsPageViewModel}">


### PR DESCRIPTION
## Summary

Add configurable shortcuts to raise, lower, or toggle mute for the focused app, and expose them in EarTrumpet's shortcut settings. Share foreground-app resolution with the Actions add-on.

## Focused-app resolution

- Resolve regular Win32 and hosted `ApplicationFrameWindow` apps.
- Inspect the full audio-session hierarchy using each stream's process ID and activity state. Target an active descendant app only when exactly one distinct descendant owns an active session, covering injected overlays.
- Fall back to the actual foreground app when the target is missing or ambiguous.
- Validate process ancestry with creation times so reused parent IDs cannot redirect controls to unrelated apps.

## Volume behavior

- Apply fixed steps of 2 percentage points in linear mode and 0.5 dB in logarithmic mode to individual streams across matching groups and devices. For example, volume-down changes 50% and 10% to 48% and 8%.
- Mute every matching stream when any is unmuted; unmute only when all are muted.
- Preserve clamping, non-finite recovery, and temporary entries used during device moves.
- Keep logarithmic readback consistent with the scalar sent to Core Audio, so repeated shortcuts work before callbacks arrive.

## Validation

- 17 deterministic regression tests pass, covering nested groups, unequal volumes, mute states, boundaries, placeholders, ancestry, PID reuse, and immediate logarithmic readback. The runner is included in PR CI.
- Release and VSDebug builds pass for x64, x86, and ARM64. Existing x86 interop warnings remain.
- An isolated live Core Audio session passed repeated linear/logarithmic adjustments and mute/unmute through the production helper, view model, and audio session.
- Debug builds remain blocked by pre-existing audio mocks missing volume-interface methods, reproduced at the original PR head.
- Full shortcut registration, Actions targeting, multiple live audio devices, and ARM64 runtime execution remain unverified.

## Scope

Toast notifications and configurable volume-step sizes remain on the separate local toast branch. This PR keeps fixed step sizes and adds no toast UI.